### PR TITLE
Config clean dead-letter queue redrive

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -148,6 +148,9 @@ Resources:
     Type: AWS::SQS::Queue
     Properties:
       KmsMasterKeyId: !GetAtt CleanQueueKmsKey.Arn
+      RedrivePolicy:
+        deadLetterTargetArn: !GetAtt CleanDeadLetterQueue.Arn
+        maxReceiveCount: 1
       QueueName: clean-queue
 
   CleanQueueKmsKey:


### PR DESCRIPTION
This redirects filtered events to be cleaned to a new queue if they fail in the first queue