### PR TITLE
Fix function timeout

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -37,7 +37,7 @@ Globals:
     PermissionsBoundary:
       !If [UsePermissionsBoundary, !Ref PermissionsBoundary, !Ref AWS::NoValue]
     Runtime: nodejs16.x
-    Timeout: 100
+    Timeout: 30
 
 Resources:
   CleanDeadLetterQueue:


### PR DESCRIPTION
This hopefully fixes a CloudFormation deployment pipeline error for CleanFunctionCleanEvent:

>Invalid request provided: Queue visibility timeout: 30 seconds is less than Function timeout: 100 seconds