### PR TITLE
Removed environment variable

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -137,6 +137,10 @@ Resources:
           Type: SQS
           Properties:
             Queue: !GetAtt FilterQueue.Arn
+      Environment:
+        Variables:
+          # checkov:skip=CKV_AWS_173: These environment variables do not require encryption.
+          OUTPUT_QUEUE_URL: !Ref CleanQueue
       Handler: src/handlers/filter/handler.handler
       Policies:
         - AWSLambdaBasicExecutionRole

--- a/template.yaml
+++ b/template.yaml
@@ -137,9 +137,6 @@ Resources:
           Type: SQS
           Properties:
             Queue: !GetAtt FilterQueue.Arn
-      Environment:
-        Variables:
-          OUTPUT_QUEUE_URL: "TODO"
       Handler: src/handlers/filter/handler.handler
       Policies:
         - AWSLambdaBasicExecutionRole


### PR DESCRIPTION
Environment variable was a dummy value anyway, and won't be used until this lambda gets deployed.  Very likely we will need different values for different environments anyway.