### PR TITLE
Fix deployment

### DIFF
--- a/src/handlers/custom-s3-object-resource/send-result.ts
+++ b/src/handlers/custom-s3-object-resource/send-result.ts
@@ -31,7 +31,7 @@ export const sendResult = async ({
 
     const body = JSON.stringify(result);
 
-    const { hostname, pathname } = new url.URL(event.ResponseURL);
+    const { hostname, pathname, search } = new url.URL(event.ResponseURL);
 
     const options = {
       headers: {
@@ -39,7 +39,7 @@ export const sendResult = async ({
       },
       hostname,
       method: "PUT",
-      path: pathname,
+      path: `${pathname}${search}`,
       port: 443,
     };
 


### PR DESCRIPTION
This fixes a deployment bug. It was caused by an erroneous custom CloudFormation resource handler result request, due to incorrect migration from a deprecated Node URL API