### PR TITLE
Transactions now in new database indexed from S3

### DIFF
--- a/cloudformation/athena.yaml
+++ b/cloudformation/athena.yaml
@@ -11,7 +11,7 @@ TransactionTable:
     CatalogId: !Ref AWS::AccountId
     DatabaseName: !Ref TransactionDB
     TableInput:
-      Name: btm-transactions
+      Name: btm_transactions
       TableType: EXTERNAL_TABLE
       Parameters:
         has_encrypted_data: "true"

--- a/cloudformation/athena.yaml
+++ b/cloudformation/athena.yaml
@@ -21,7 +21,7 @@ TransactionTable:
         projection.datetime.format: 'yyyy-MM-dd'
         projection.datetime.interval: 1
         projection.datetime.interval.unit: DAYS
-        storage.location.template: !Join [ '', [ 's3://', !Ref StorageBucket, '/${datetime}/' ] ]
+        storage.location.template: !Join [ '', [ 's3://', !Ref StorageBucket, '/btm_transactions/${datetime}/' ] ]
       PartitionKeys:
         - { Name: "datetime", Type: date }
       StorageDescriptor:

--- a/integration_tests/helpers/athenaHelper.ts
+++ b/integration_tests/helpers/athenaHelper.ts
@@ -35,7 +35,7 @@ async function startQueryExecutionCommand(eventId: any) {
     QueryExecutionContext: {
       Database: await getDatabaseName(),
     },
-    QueryString: `SELECT * FROM \"btm-transactions\" where event_id='${eventId.toString()}'`,
+    QueryString: `SELECT * FROM \"btm_transactions\" where event_id='${eventId.toString()}'`,
     WorkGroup: await getWorkGroupName(),
   };
   const response = await athenaClient.send(


### PR DESCRIPTION
This fixes the storage location of events and the subsequent indexing and querying, so that manual testing can still work in S3.

Not included (but coming soon) are the actual CloudFormation changes to create the crawler.