### PR TITLE
Refactor lambda tests

### DIFF
--- a/integration_tests/helpers/cloudWatchHelper.ts
+++ b/integration_tests/helpers/cloudWatchHelper.ts
@@ -30,12 +30,7 @@ async function getLogGroupName(logName: string) {
   return name;
 }
 
-let events: FilteredLogEvent[];
-
-async function checkEventExistsInLogs(
-  logName: string,
-  eventid: string
-) {
+async function checkEventExistsInLogs(logName: string, eventid: string) {
   const params: FilterLogEventsCommandInput = {
     logGroupName: await getLogGroupName(logName),
     startTime: testStartTime,
@@ -44,10 +39,7 @@ async function checkEventExistsInLogs(
   const checkEventExists = async () => {
     const response: FilterLogEventsCommandOutput =
       await cloudWatchLogsClient.send(new FilterLogEventsCommand(params));
-    events = response.events ?? [];
-    return JSON.stringify(response.events?.filter((x) => x.eventId)).includes(
-      eventid
-    );
+    return response.events?.some((x) => x.message?.includes(eventid));
   };
   const eventIdExists = await waitForTrue(checkEventExists, 3000, 15000);
   return eventIdExists;

--- a/integration_tests/helpers/cloudWatchHelper.ts
+++ b/integration_tests/helpers/cloudWatchHelper.ts
@@ -1,7 +1,4 @@
 import {
-  DescribeLogStreamsCommand,
-  DescribeLogStreamsCommandOutput,
-  LogStream,
   FilterLogEventsCommandInput,
   FilterLogEventsCommandOutput,
   FilteredLogEvent,
@@ -12,10 +9,8 @@ import {
 } from "@aws-sdk/client-cloudwatch-logs";
 
 import { cloudWatchLogsClient } from "../clients/cloudWatchLogsClient";
-
 import { testStartTime } from "../tests/sns-lambda-tests";
-
-import delay from "delay";
+import { waitForTrue } from "../helpers/commonHelpers";
 
 async function getLogGroupsList() {
   const params = {};
@@ -35,48 +30,27 @@ async function getLogGroupName(logName: string) {
   return name;
 }
 
-async function getCloudWatchLatestLogStreams(logName: string) {
-  const params = {
-    logGroupName: await getLogGroupName(logName),
-    orderBy: "LastEventTime",
-    descending: true,
-    limit: 1,
-  };
-  await delay(10000); //time delay
-  console.log("WAITED 10s FOR THE LOG TO POPULATE IN CLOUDWATCH");
-  const response: DescribeLogStreamsCommandOutput =
-    await cloudWatchLogsClient.send(new DescribeLogStreamsCommand(params));
-  const latestLogStearmResponse: LogStream[] = response.logStreams ?? [];
-  return latestLogStearmResponse;
-}
+let events: FilteredLogEvent[];
 
-async function getCloudWatchLatestLogStreamName(logName: string) {
-  const logStream: LogStream[] = await getCloudWatchLatestLogStreams(logName);
-  if (logStream.length > 0) {
-    const result = logStream[0].logStreamName as string;
-    return result;
-  } else {
-    throw Error("No log streams found");
-  }
-}
-
-async function getFilteredEventFromLatestLogStream(logName: string) {
-  const latestLogStreamName = await getCloudWatchLatestLogStreamName(logName);
-  console.log("Latest Log StreamName:", latestLogStreamName);
+async function getFilteredEventFromLatestLogStream(
+  logName: string,
+  eventid: string
+) {
   const params: FilterLogEventsCommandInput = {
     logGroupName: await getLogGroupName(logName),
-    logStreamNamePrefix: latestLogStreamName,
     startTime: testStartTime,
   };
-  console.log("Filtered parameters:", params);
-  const response: FilterLogEventsCommandOutput =
-    await cloudWatchLogsClient.send(new FilterLogEventsCommand(params));
-    const events: FilteredLogEvent[] = response.events ?? [];
-  if (events.length > 0) {
-    return events;
-  } else {
-    throw Error("Filtered events empty");
-  }
+
+  const checkLogEventExists = async () => {
+    const response: FilterLogEventsCommandOutput =
+      await cloudWatchLogsClient.send(new FilterLogEventsCommand(params));
+    events = response.events ?? [];
+    return JSON.stringify(response.events?.filter((x) => x.eventId)).includes(
+      eventid
+    );
+  };
+  const eventIdExists = await waitForTrue(checkLogEventExists, 3000, 15000);
+  return eventIdExists;
 }
 
 export { getFilteredEventFromLatestLogStream, getLogGroupName };

--- a/integration_tests/helpers/cloudWatchHelper.ts
+++ b/integration_tests/helpers/cloudWatchHelper.ts
@@ -32,7 +32,7 @@ async function getLogGroupName(logName: string) {
 
 let events: FilteredLogEvent[];
 
-async function getFilteredEventFromLatestLogStream(
+async function checkEventExistsInLogs(
   logName: string,
   eventid: string
 ) {
@@ -41,7 +41,7 @@ async function getFilteredEventFromLatestLogStream(
     startTime: testStartTime,
   };
 
-  const checkLogEventExists = async () => {
+  const checkEventExists = async () => {
     const response: FilterLogEventsCommandOutput =
       await cloudWatchLogsClient.send(new FilterLogEventsCommand(params));
     events = response.events ?? [];
@@ -49,8 +49,8 @@ async function getFilteredEventFromLatestLogStream(
       eventid
     );
   };
-  const eventIdExists = await waitForTrue(checkLogEventExists, 3000, 15000);
+  const eventIdExists = await waitForTrue(checkEventExists, 3000, 15000);
   return eventIdExists;
 }
 
-export { getFilteredEventFromLatestLogStream, getLogGroupName };
+export { checkEventExistsInLogs, getLogGroupName };

--- a/integration_tests/tests/sns-lambda-tests.ts
+++ b/integration_tests/tests/sns-lambda-tests.ts
@@ -26,43 +26,33 @@ describe(
 
     test("Filter function cloud watch logs should contain eventid", async () => {
       expect(snsResponse).toHaveProperty("MessageId");
-      const logs = await getFilteredEventFromLatestLogStream(
-        "di-btm-FilterFunction"
+      const eventIdExists = await getFilteredEventFromLatestLogStream(
+        "di-btm-FilterFunction",snsValidEventPayload.event_id
       );
-      expect(JSON.stringify(logs)).not.toContain("ERROR");
-      expect(JSON.stringify(logs)).toContain(
-        snsValidEventPayload.event_id.toString()
-      );
+     expect(eventIdExists).toBeTruthy()
     });
 
     test("Clean function cloud watch logs should contain eventid", async () => {
-      const logs = await getFilteredEventFromLatestLogStream(
-        "di-btm-CleanFunction"
+      const eventIdExists = await getFilteredEventFromLatestLogStream(
+        "di-btm-CleanFunction",snsValidEventPayload.event_id
       );
-      expect(JSON.stringify(logs)).toContain(
-        snsValidEventPayload.event_id.toString()
-      );
+      expect(eventIdExists).toBeTruthy()
     });
 
     test("Store function cloud watch logs should contain eventid", async () => {
-      const logs = await getFilteredEventFromLatestLogStream(
-        "di-btm-StorageFunction"
+      const eventIdExists = await getFilteredEventFromLatestLogStream(
+        "di-btm-StorageFunction",snsValidEventPayload.event_id
       );
-      expect(JSON.stringify(logs)).not.toContain("ERROR");
-      expect(JSON.stringify(logs)).toContain(
-        snsValidEventPayload.event_id.toString()
-      );
+      expect(eventIdExists).toBeTruthy()
     });
 
     test("Clean function cloud watch logs should contain event id for SNS message with some additional field in the payload", async () => {
       snsResponse = await publishSNS(snsEventWithAdditionalFieldsPayload);
       expect(snsResponse).toHaveProperty("MessageId");
-      const logs = await getFilteredEventFromLatestLogStream(
-        "di-btm-CleanFunction"
+      const eventIdExists = await getFilteredEventFromLatestLogStream(
+        "di-btm-CleanFunction",snsEventWithAdditionalFieldsPayload.event_id
       );
-      expect(JSON.stringify(logs)).toContain(
-        snsEventWithAdditionalFieldsPayload.event_id.toString()
-      );
+      expect(eventIdExists).toBeTruthy()
     });
   }
 );
@@ -74,69 +64,59 @@ describe(
     test("Filter function cloud watch logs should not contain eventid for sns message with invalid event name", async () => {
       snsResponse = await publishSNS(snsInvalidEventNamePayload);
       expect(snsResponse).toHaveProperty("MessageId");
-      const logs = await getFilteredEventFromLatestLogStream(
-        "di-btm-FilterFunction"
+      const eventIdExists = await getFilteredEventFromLatestLogStream(
+        "di-btm-FilterFunction",snsInvalidEventNamePayload.event_id
       );
-      expect(JSON.stringify(logs)).not.toContain("ERROR");
-      expect(JSON.stringify(logs)).not.toContain(
-        snsInvalidEventNamePayload.event_id.toString()
-      );
+      expect(eventIdExists).toBeFalsy()
     });
 
     test("Clean function cloud watch logs should not contain eventid for SNS message with invalid Timestamp in the payload", async () => {
       snsResponse = await publishSNS(snsInvalidTimeStampPayload);
       expect(snsResponse).toHaveProperty("MessageId");
-      const logs = await getFilteredEventFromLatestLogStream(
-        "di-btm-CleanFunction"
+      const eventIdExists = await getFilteredEventFromLatestLogStream(
+        "di-btm-CleanFunction",snsInvalidTimeStampPayload.event_id
       );
-      expect(JSON.stringify(logs)).not.toContain(
-        snsInvalidTimeStampPayload.event_id.toString()
-      );
+      expect(eventIdExists).toBeFalsy()
     });
 
     test("Clean function cloud watch logs should not contain eventid for SNS  message with invalid ComponentId in the payload", async () => {
       snsResponse = await publishSNS(snsEventInvalidCompId);
       expect(snsResponse).toHaveProperty("MessageId");
-      const logs = await getFilteredEventFromLatestLogStream(
-        "di-btm-CleanFunction"
+      const eventIdExists = await getFilteredEventFromLatestLogStream(
+        "di-btm-CleanFunction",snsEventInvalidCompId.event_id
       );
-      expect(JSON.stringify(logs)).not.toContain(
-        snsEventInvalidCompId.event_id.toString()
-      );
+      expect(eventIdExists).toBeFalsy()
     });
 
     test("Filter function cloud watch logs should not contain event id for SNS message with missing EventName in the payload", async () => {
       snsResponse = await publishSNS(snsMissingEventNamePayload);
       expect(snsResponse).toHaveProperty("MessageId");
-      const logs = await getFilteredEventFromLatestLogStream(
-        "di-btm-FilterFunction"
+      const eventIdExists = await getFilteredEventFromLatestLogStream(
+        "di-btm-FilterFunction",snsMissingEventNamePayload.event_id
       );
-      expect(JSON.stringify(logs)).not.toContain("ERROR");
-      expect(JSON.stringify(logs)).not.toContain(
-        snsMissingEventNamePayload.event_id.toString()
-      );
+      expect(eventIdExists).toBeFalsy()
     });
 
     test("Clean function cloud watch logs should not contain event id for SNS message with missing ComponentId in the payload", async () => {
       snsResponse = await publishSNS(snsEventMissingCompIdPayload);
       expect(snsResponse).toHaveProperty("MessageId");
-      const logs = await getFilteredEventFromLatestLogStream(
-        "di-btm-CleanFunction"
+      const eventIdExists = await getFilteredEventFromLatestLogStream(
+        "di-btm-CleanFunction",snsEventMissingCompIdPayload.event_id
       );
-      expect(JSON.stringify(logs)).not.toContain(
-        snsEventMissingCompIdPayload.event_id.toString()
-      );
+      expect(eventIdExists).toBeFalsy()
+   
     });
 
     test("Clean function cloud watch logs should not contain event id for SNS message with missing Timestamp in the payload", async () => {
       snsResponse = await publishSNS(snsEventMissingTimestampPayload);
       expect(snsResponse).toHaveProperty("MessageId");
-      const logs = await getFilteredEventFromLatestLogStream(
-        "di-btm-CleanFunction"
+      const eventIdExists = await getFilteredEventFromLatestLogStream(
+        "di-btm-CleanFunction",snsEventMissingTimestampPayload.event_id
       );
-      expect(JSON.stringify(logs)).not.toContain(
-        snsEventMissingTimestampPayload.event_id.toString()
-      );
+      expect(eventIdExists).toBeFalsy()
+      
     });
   }
 );
+
+

--- a/integration_tests/tests/sns-lambda-tests.ts
+++ b/integration_tests/tests/sns-lambda-tests.ts
@@ -1,5 +1,5 @@
 import { publishSNS } from "../helpers/snsHelper";
-import { getFilteredEventFromLatestLogStream } from "../helpers/cloudWatchHelper";
+import { checkEventExistsInLogs } from "../helpers/cloudWatchHelper";
 import { PublishResponse } from "@aws-sdk/client-sns";
 import {
   snsValidEventPayload,
@@ -26,21 +26,21 @@ describe(
 
     test("Filter function cloud watch logs should contain eventid", async () => {
       expect(snsResponse).toHaveProperty("MessageId");
-      const eventIdExists = await getFilteredEventFromLatestLogStream(
+      const eventIdExists = await checkEventExistsInLogs(
         "di-btm-FilterFunction",snsValidEventPayload.event_id
       );
      expect(eventIdExists).toBeTruthy()
     });
 
     test("Clean function cloud watch logs should contain eventid", async () => {
-      const eventIdExists = await getFilteredEventFromLatestLogStream(
+      const eventIdExists = await checkEventExistsInLogs(
         "di-btm-CleanFunction",snsValidEventPayload.event_id
       );
       expect(eventIdExists).toBeTruthy()
     });
 
     test("Store function cloud watch logs should contain eventid", async () => {
-      const eventIdExists = await getFilteredEventFromLatestLogStream(
+      const eventIdExists = await checkEventExistsInLogs(
         "di-btm-StorageFunction",snsValidEventPayload.event_id
       );
       expect(eventIdExists).toBeTruthy()
@@ -49,7 +49,7 @@ describe(
     test("Clean function cloud watch logs should contain event id for SNS message with some additional field in the payload", async () => {
       snsResponse = await publishSNS(snsEventWithAdditionalFieldsPayload);
       expect(snsResponse).toHaveProperty("MessageId");
-      const eventIdExists = await getFilteredEventFromLatestLogStream(
+      const eventIdExists = await checkEventExistsInLogs(
         "di-btm-CleanFunction",snsEventWithAdditionalFieldsPayload.event_id
       );
       expect(eventIdExists).toBeTruthy()
@@ -64,7 +64,7 @@ describe(
     test("Filter function cloud watch logs should not contain eventid for sns message with invalid event name", async () => {
       snsResponse = await publishSNS(snsInvalidEventNamePayload);
       expect(snsResponse).toHaveProperty("MessageId");
-      const eventIdExists = await getFilteredEventFromLatestLogStream(
+      const eventIdExists = await checkEventExistsInLogs(
         "di-btm-FilterFunction",snsInvalidEventNamePayload.event_id
       );
       expect(eventIdExists).toBeFalsy()
@@ -73,7 +73,7 @@ describe(
     test("Clean function cloud watch logs should not contain eventid for SNS message with invalid Timestamp in the payload", async () => {
       snsResponse = await publishSNS(snsInvalidTimeStampPayload);
       expect(snsResponse).toHaveProperty("MessageId");
-      const eventIdExists = await getFilteredEventFromLatestLogStream(
+      const eventIdExists = await checkEventExistsInLogs(
         "di-btm-CleanFunction",snsInvalidTimeStampPayload.event_id
       );
       expect(eventIdExists).toBeFalsy()
@@ -82,7 +82,7 @@ describe(
     test("Clean function cloud watch logs should not contain eventid for SNS  message with invalid ComponentId in the payload", async () => {
       snsResponse = await publishSNS(snsEventInvalidCompId);
       expect(snsResponse).toHaveProperty("MessageId");
-      const eventIdExists = await getFilteredEventFromLatestLogStream(
+      const eventIdExists = await checkEventExistsInLogs(
         "di-btm-CleanFunction",snsEventInvalidCompId.event_id
       );
       expect(eventIdExists).toBeFalsy()
@@ -91,7 +91,7 @@ describe(
     test("Filter function cloud watch logs should not contain event id for SNS message with missing EventName in the payload", async () => {
       snsResponse = await publishSNS(snsMissingEventNamePayload);
       expect(snsResponse).toHaveProperty("MessageId");
-      const eventIdExists = await getFilteredEventFromLatestLogStream(
+      const eventIdExists = await checkEventExistsInLogs(
         "di-btm-FilterFunction",snsMissingEventNamePayload.event_id
       );
       expect(eventIdExists).toBeFalsy()
@@ -100,7 +100,7 @@ describe(
     test("Clean function cloud watch logs should not contain event id for SNS message with missing ComponentId in the payload", async () => {
       snsResponse = await publishSNS(snsEventMissingCompIdPayload);
       expect(snsResponse).toHaveProperty("MessageId");
-      const eventIdExists = await getFilteredEventFromLatestLogStream(
+      const eventIdExists = await checkEventExistsInLogs(
         "di-btm-CleanFunction",snsEventMissingCompIdPayload.event_id
       );
       expect(eventIdExists).toBeFalsy()
@@ -110,7 +110,7 @@ describe(
     test("Clean function cloud watch logs should not contain event id for SNS message with missing Timestamp in the payload", async () => {
       snsResponse = await publishSNS(snsEventMissingTimestampPayload);
       expect(snsResponse).toHaveProperty("MessageId");
-      const eventIdExists = await getFilteredEventFromLatestLogStream(
+      const eventIdExists = await checkEventExistsInLogs(
         "di-btm-CleanFunction",snsEventMissingTimestampPayload.event_id
       );
       expect(eventIdExists).toBeFalsy()


### PR DESCRIPTION
Removed filtered events by latestlogstreams. When getting the latest log stream sometimes are there two logSteams created for single test run and some events end up in second latest logstreams. So refactored filtered events function to search in all the logStreams.
Also, removed time delay and added waitForTrue function 