### PR TITLE
Fix PDF store

### DIFF
--- a/template-source.yaml
+++ b/template-source.yaml
@@ -60,5 +60,5 @@ Resources: !YAMLInclude ./cloudformation/global.yaml,
   ./cloudformation/athena.yaml#NO_LOCAL,
   ./cloudformation/config-store.yaml#NO_LOCAL,
   ./cloudformation/custom-s3-object-resource.yaml#NO_LOCAL,
-  ./cloudformation/alerting.yaml#NO_LOCAL
+  ./cloudformation/alerting.yaml#NO_LOCAL,
   ./cloudformation/raw-invoice-pdf-store.yaml


### PR DESCRIPTION
This fixes a bug where the Simple Storage Service bucket was not deployed. It was caused by a missing comma