### PR TITLE
BTM-184: Fix alarms

### DIFF
--- a/cloudformation/cleaning.yaml
+++ b/cloudformation/cleaning.yaml
@@ -36,6 +36,8 @@ CleanFunction:
       CleanEvent:
         Type: SQS
         Properties:
+          FunctionResponseTypes:
+            - ReportBatchItemFailures
           Queue: !GetAtt CleanQueue.Arn
     Handler: clean.handler
     KmsKeyArn: !GetAtt KmsKey.Arn

--- a/cloudformation/filtering.yaml
+++ b/cloudformation/filtering.yaml
@@ -32,6 +32,8 @@ FilterFunction:
       FilterEvent:
         Type: SQS
         Properties:
+          FunctionResponseTypes:
+            - ReportBatchItemFailures
           Queue: !GetAtt FilterQueue.Arn
     Environment:
       Variables:

--- a/cloudformation/storage.yaml
+++ b/cloudformation/storage.yaml
@@ -119,6 +119,8 @@ StorageFunction:
       StorageEvent:
         Type: SQS
         Properties:
+          FunctionResponseTypes:
+            - ReportBatchItemFailures
           Queue: !GetAtt StorageQueue.Arn
     Environment:
       Variables:


### PR DESCRIPTION
This fixes a bug where function alarms were not being triggered. It was caused by returning batch failures without enabling batch failures

(Note: [the Amazon Serverless Application Model property that I use here to enable batch item failures lacks documentation](https://github.com/aws/serverless-application-model/issues/2256))