### PR TITLE
BTM-201: Fix deployment

### DIFF
--- a/cloudformation/raw-invoice-pdf-store.yaml
+++ b/cloudformation/raw-invoice-pdf-store.yaml
@@ -20,7 +20,7 @@ RawInvoicePdfBucket:
     NotificationConfiguration:
       QueueConfigurations:
         - Event: s3:ObjectCreated:*
-          Queue: !Ref ExtractQueue
+          Queue: !GetAtt ExtractQueue.Arn
 
 RawInvoicePdfLogBucket:
   # checkov:skip=CKV_AWS_18: This is the raw invoice pdf log bucket - no need for another


### PR DESCRIPTION
This fixes a bug that prevented deployment. It was caused by accidentally using a URL instead and ARN in the CloudFormation template, as different resources return different types of values from the `!Ref` function