### PR TITLE
BTM-184: Fix alarms

### DIFF
--- a/cloudformation/cleaning.yaml
+++ b/cloudformation/cleaning.yaml
@@ -11,14 +11,22 @@ CleanDeadLetterQueueAlarm:
     AlarmActions:
       - !Ref AlarmTopic
     ComparisonOperator: GreaterThanThreshold
-    Dimensions:
-      - Name: QueueName
-        Value: !GetAtt CleanDeadLetterQueue.QueueName
     EvaluationPeriods: 1
-    MetricName: NumberOfMessagesSent
-    Namespace: AWS/SQS
-    Period: 1800
-    Statistic: Sum
+    Metrics:
+      - Id: messages
+        MetricStat:
+          Metric:
+            Dimensions:
+              - Name: QueueName
+                Value: !GetAtt CleanDeadLetterQueue.QueueName
+            MetricName: ApproximateNumberOfMessagesVisible
+            Namespace: AWS/SQS
+          Period: 1800
+          Stat: Sum
+        ReturnData: false
+      - Id: messagesRate
+        Expression: RATE(messages)
+        ReturnData: true
     Threshold: 0
 
 CleanFunction:
@@ -91,14 +99,22 @@ CleanFunctionDeadLetterQueueAlarm:
     AlarmActions:
       - !Ref AlarmTopic
     ComparisonOperator: GreaterThanThreshold
-    Dimensions:
-      - Name: QueueName
-        Value: !GetAtt CleanFunctionDeadLetterQueue.QueueName
     EvaluationPeriods: 1
-    MetricName: NumberOfMessagesSent
-    Namespace: AWS/SQS
-    Period: 1800
-    Statistic: Sum
+    Metrics:
+      - Id: messages
+        MetricStat:
+          Metric:
+            Dimensions:
+              - Name: QueueName
+                Value: !GetAtt CleanFunctionDeadLetterQueue.QueueName
+            MetricName: ApproximateNumberOfMessagesVisible
+            Namespace: AWS/SQS
+          Period: 1800
+          Stat: Sum
+        ReturnData: false
+      - Id: messagesRate
+        Expression: RATE(messages)
+        ReturnData: true
     Threshold: 0
 
 CleanQueue:

--- a/cloudformation/filtering.yaml
+++ b/cloudformation/filtering.yaml
@@ -11,14 +11,22 @@ FilterDeadLetterQueueAlarm:
     AlarmActions:
       - !Ref AlarmTopic
     ComparisonOperator: GreaterThanThreshold
-    Dimensions:
-      - Name: QueueName
-        Value: !GetAtt FilterDeadLetterQueue.QueueName
     EvaluationPeriods: 1
-    MetricName: NumberOfMessagesSent
-    Namespace: AWS/SQS
-    Period: 1800
-    Statistic: Sum
+    Metrics:
+      - Id: messages
+        MetricStat:
+          Metric:
+            Dimensions:
+              - Name: QueueName
+                Value: !GetAtt FilterDeadLetterQueue.QueueName
+            MetricName: ApproximateNumberOfMessagesVisible
+            Namespace: AWS/SQS
+          Period: 1800
+          Stat: Sum
+        ReturnData: false
+      - Id: messagesRate
+        Expression: RATE(messages)
+        ReturnData: true
     Threshold: 0
 
 FilterFunction:
@@ -91,14 +99,22 @@ FilterFunctionDeadLetterQueueAlarm:
     AlarmActions:
       - !Ref AlarmTopic
     ComparisonOperator: GreaterThanThreshold
-    Dimensions:
-      - Name: QueueName
-        Value: !GetAtt FilterFunctionDeadLetterQueue.QueueName
     EvaluationPeriods: 1
-    MetricName: NumberOfMessagesSent
-    Namespace: AWS/SQS
-    Period: 1800
-    Statistic: Sum
+    Metrics:
+      - Id: messages
+        MetricStat:
+          Metric:
+            Dimensions:
+              - Name: QueueName
+                Value: !GetAtt FilterFunctionDeadLetterQueue.QueueName
+            MetricName: ApproximateNumberOfMessagesVisible
+            Namespace: AWS/SQS
+          Period: 1800
+          Stat: Sum
+        ReturnData: false
+      - Id: messagesRate
+        Expression: RATE(messages)
+        ReturnData: true
     Threshold: 0
 
 FilterQueue:

--- a/cloudformation/storage.yaml
+++ b/cloudformation/storage.yaml
@@ -98,14 +98,22 @@ StorageDeadLetterQueueAlarm:
     AlarmActions:
       - !Ref AlarmTopic
     ComparisonOperator: GreaterThanThreshold
-    Dimensions:
-      - Name: QueueName
-        Value: !GetAtt StorageDeadLetterQueue.QueueName
     EvaluationPeriods: 1
-    MetricName: NumberOfMessagesSent
-    Namespace: AWS/SQS
-    Period: 1800
-    Statistic: Sum
+    Metrics:
+      - Id: messages
+        MetricStat:
+          Metric:
+            Dimensions:
+              - Name: QueueName
+                Value: !GetAtt StorageDeadLetterQueue.QueueName
+            MetricName: ApproximateNumberOfMessagesVisible
+            Namespace: AWS/SQS
+          Period: 1800
+          Stat: Sum
+        ReturnData: false
+      - Id: messagesRate
+        Expression: RATE(messages)
+        ReturnData: true
     Threshold: 0
 
 StorageFunction:
@@ -191,12 +199,20 @@ StorageFunctionDeadLetterQueueAlarm:
     AlarmActions:
       - !Ref AlarmTopic
     ComparisonOperator: GreaterThanThreshold
-    Dimensions:
-      - Name: QueueName
-        Value: !GetAtt StorageFunctionDeadLetterQueue.QueueName
     EvaluationPeriods: 1
-    MetricName: NumberOfMessagesSent
-    Namespace: AWS/SQS
-    Period: 1800
-    Statistic: Sum
+    Metrics:
+      - Id: messages
+        MetricStat:
+          Metric:
+            Dimensions:
+              - Name: QueueName
+                Value: !GetAtt StorageFunctionDeadLetterQueue.QueueName
+            MetricName: ApproximateNumberOfMessagesVisible
+            Namespace: AWS/SQS
+          Period: 1800
+          Stat: Sum
+        ReturnData: false
+      - Id: messagesRate
+        Expression: RATE(messages)
+        ReturnData: true
     Threshold: 0


### PR DESCRIPTION
This fixes a bug where queue alarms were not being triggered. It was caused by a misunderstanding of the `NumberOfMessagesSent` metric (it is the number of messages sent to *any* queue *by the given queue*, not messages sent *to* the given queue from anywhere)