### PR TITLE
added s3 bucket to store invoice for int tests

### DIFF
--- a/cloudformation/test-invoice-pdf-store.yaml
+++ b/cloudformation/test-invoice-pdf-store.yaml
@@ -1,0 +1,37 @@
+TestInvoicePdfBucket:
+  Type: AWS::S3::Bucket
+  Properties:
+    AccessControl: Private
+    PublicAccessBlockConfiguration:
+      BlockPublicAcls: true
+      BlockPublicPolicy: true
+      IgnorePublicAcls: true
+      RestrictPublicBuckets: true
+    BucketEncryption:
+      ServerSideEncryptionConfiguration:
+        - ServerSideEncryptionByDefault:
+            SSEAlgorithm: aws:kms
+            KMSMasterKeyID: !GetAtt KmsKey.Arn
+    VersioningConfiguration:
+      Status: Enabled
+    LoggingConfiguration:
+      DestinationBucketName: !Ref TestInvoicePdfLogBucket
+      LogFilePrefix: test-invoice-pdf-bucket-log
+
+TestInvoicePdfLogBucket:
+  # checkov:skip=CKV_AWS_18: This is the test invoice pdf log bucket - no need for another
+  Type: AWS::S3::Bucket
+  Properties:
+    VersioningConfiguration:
+      Status: Enabled
+    AccessControl: LogDeliveryWrite
+    PublicAccessBlockConfiguration:
+      BlockPublicAcls: true
+      BlockPublicPolicy: true
+      IgnorePublicAcls: true
+      RestrictPublicBuckets: true
+    BucketEncryption:
+      ServerSideEncryptionConfiguration:
+        - ServerSideEncryptionByDefault:
+            SSEAlgorithm: aws:kms
+            KMSMasterKeyID: !GetAtt KmsKey.Arn

--- a/template-source.yaml
+++ b/template-source.yaml
@@ -49,6 +49,7 @@ Resources: !YAMLInclude ./cloudformation/global.yaml,
   ./cloudformation/custom-s3-object-resource.yaml#NO_LOCAL,
   ./cloudformation/raw-invoice-textract-data-store.yaml,
   ./cloudformation/raw-invoice-pdf-store.yaml,
+  ./cloudformation/test-invoice-pdf-store.yaml,
   ./cloudformation/validated-invoice-data-store.yaml,
   ./cloudformation/extraction.yaml
 


### PR DESCRIPTION
my first build ticket :) 
This s3 bucket to hold invoice pdfs used to test via integration tests. As these invoices files cannot be stored in github.