### PR TITLE
BTM-215 Fix date and month formatting to be 2-digits to index data for athena

### DIFF
--- a/src/handlers/store-transactions/handler.test.ts
+++ b/src/handlers/store-transactions/handler.test.ts
@@ -27,6 +27,13 @@ afterAll(() => {
   console.log = oldConsoleLog;
 });
 
+function formatDate(date: Date): string {
+  const year = date.getUTCFullYear();
+  const month = ("0" + String(date.getUTCMonth() + 1)).slice(-2);
+  const day = ("0" + String(date.getUTCDate())).slice(-2);
+  return `${year}-${month}-${day}`;
+}
+
 test("Store Transactions handler with empty event batch", async () => {
   const event = createEvent([]);
 
@@ -52,9 +59,10 @@ test("Store Transactions handler with some valid events calls s3", async () => {
 
   const recordBody1 = JSON.parse(validRecord1.body);
   const expectedDate1 = new Date(recordBody1.timestamp);
-  const expectedKey1 = `btm_transactions/${expectedDate1.getUTCFullYear()}-${
-    expectedDate1.getUTCMonth() + 1
-  }-${expectedDate1.getUTCDate()}/${recordBody1.event_id as string}.json`;
+  const formattedDate1 = formatDate(expectedDate1);
+  const expectedKey1 = `btm_transactions/${formattedDate1}/${
+    recordBody1.event_id as string
+  }.json`;
   expect(mockPutS3).toHaveBeenNthCalledWith(
     1,
     "store",
@@ -64,9 +72,10 @@ test("Store Transactions handler with some valid events calls s3", async () => {
 
   const recordBody2 = JSON.parse(validRecord2.body);
   const expectedDate2 = new Date(recordBody2.timestamp);
-  const expectedKey2 = `btm_transactions/${expectedDate2.getUTCFullYear()}-${
-    expectedDate2.getUTCMonth() + 1
-  }-${expectedDate2.getUTCDate()}/${recordBody2.event_id as string}.json`;
+  const formattedDate2 = formatDate(expectedDate2);
+  const expectedKey2 = `btm_transactions/${formattedDate2}/${
+    recordBody2.event_id as string
+  }.json`;
   expect(mockPutS3).toHaveBeenNthCalledWith(
     2,
     "store",
@@ -127,9 +136,10 @@ test("Failing puts to S3", async () => {
 
   const recordBody1 = JSON.parse(validRecord.body);
   const expectedDate1 = new Date(recordBody1.timestamp);
-  const expectedKey1 = `btm_transactions/${expectedDate1.getUTCFullYear()}-${
-    expectedDate1.getUTCMonth() + 1
-  }-${expectedDate1.getUTCDate()}/${recordBody1.event_id as string}.json`;
+  const formattedDate1 = formatDate(expectedDate1);
+  const expectedKey1 = `btm_transactions/${formattedDate1}/${
+    recordBody1.event_id as string
+  }.json`;
   expect(mockPutS3).toHaveBeenNthCalledWith(
     1,
     "store",
@@ -139,9 +149,11 @@ test("Failing puts to S3", async () => {
 
   const recordBody2 = JSON.parse(invalidRecord.body);
   const expectedDate2 = new Date(recordBody2.timestamp);
-  const expectedKey2 = `btm_transactions/${expectedDate2.getUTCFullYear()}-${
-    expectedDate2.getUTCMonth() + 1
-  }-${expectedDate2.getUTCDate()}/${recordBody2.event_id as string}.json`;
+  const formattedDate2 = formatDate(expectedDate2);
+
+  const expectedKey2 = `btm_transactions/${formattedDate2}/${
+    recordBody2.event_id as string
+  }.json`;
   expect(mockPutS3).toHaveBeenNthCalledWith(
     2,
     "store",

--- a/src/handlers/store-transactions/handler.test.ts
+++ b/src/handlers/store-transactions/handler.test.ts
@@ -3,7 +3,7 @@ import {
   createEvent,
   createEventRecordWithName,
 } from "../../../test-helpers/SQS";
-import { putS3 } from "../../shared/utils";
+import { formatDate, putS3 } from "../../shared/utils";
 
 jest.mock("../../shared/utils");
 const mockPutS3 = putS3 as jest.MockedFunction<typeof putS3>;
@@ -26,13 +26,6 @@ afterAll(() => {
   console.error = oldConsoleError;
   console.log = oldConsoleLog;
 });
-
-function formatDate(date: Date): string {
-  const year = date.getUTCFullYear();
-  const month = ("0" + String(date.getUTCMonth() + 1)).slice(-2);
-  const day = ("0" + String(date.getUTCDate())).slice(-2);
-  return `${year}-${month}-${day}`;
-}
 
 test("Store Transactions handler with empty event batch", async () => {
   const event = createEvent([]);

--- a/src/handlers/store-transactions/handler.ts
+++ b/src/handlers/store-transactions/handler.ts
@@ -45,11 +45,17 @@ async function storeRecord(record: SQSRecord): Promise<void> {
     console.error(message);
     throw new Error(message);
   }
-  
-  const date = new Date(timestamp);
-  const key = `${date.getUTCFullYear()}-${
-    date.getUTCMonth() + 1
-  }-${date.getUTCDate()}/${eventId}.json`;
 
-  await putS3(process.env.STORAGE_BUCKET, process.env.TRANSACTIONS_FOLDER + '/' + key, bodyObject);
+  const date = new Date(timestamp);
+  const year = date.getUTCFullYear();
+  const month = ("0" + String(date.getUTCMonth() + 1)).slice(-2);
+  const day = ("0" + String(date.getUTCDate())).slice(-2);
+
+  const key = `${year}-${month}-${day}/${eventId}.json`;
+
+  await putS3(
+    process.env.STORAGE_BUCKET,
+    process.env.TRANSACTIONS_FOLDER + "/" + key,
+    bodyObject
+  );
 }

--- a/src/handlers/store-transactions/handler.ts
+++ b/src/handlers/store-transactions/handler.ts
@@ -1,6 +1,6 @@
 import { SQSEvent, SQSRecord } from "aws-lambda";
 import { Response } from "../../shared/types";
-import { putS3 } from "../../shared/utils";
+import { formatDate, putS3 } from "../../shared/utils";
 
 export const handler = async (event: SQSEvent): Promise<Response> => {
   const response: Response = { batchItemFailures: [] };
@@ -47,11 +47,9 @@ async function storeRecord(record: SQSRecord): Promise<void> {
   }
 
   const date = new Date(timestamp);
-  const year = date.getUTCFullYear();
-  const month = ("0" + String(date.getUTCMonth() + 1)).slice(-2);
-  const day = ("0" + String(date.getUTCDate())).slice(-2);
+  const formattedDate = formatDate(date);
 
-  const key = `${year}-${month}-${day}/${eventId}.json`;
+  const key = `${formattedDate}/${eventId}.json`;
 
   await putS3(
     process.env.STORAGE_BUCKET,

--- a/src/shared/utils/date-utils.test.ts
+++ b/src/shared/utils/date-utils.test.ts
@@ -1,0 +1,23 @@
+import { formatDate } from "./date-utils";
+
+test("Date is formatted to yyyy-mm-dd with a month that is single digits", async () => {
+  const date: Date = new Date("2022-01-16");
+  const formattedDate = formatDate(date);
+  expect(formattedDate).toEqual("2022-01-16");
+});
+
+test("Date is formatted to yyyy-mm-dd with a date that is single digits", async () => {
+  const date: Date = new Date("2022-10-01");
+  console.log(date);
+  const formattedDate = formatDate(date);
+  console.log(formattedDate);
+  expect(formattedDate).toEqual("2022-10-01");
+});
+
+test("Date is formatted to yyyy-mm-dd with a date and month that is not single digits", async () => {
+  const date: Date = new Date("2022-12-25");
+  console.log(date);
+  const formattedDate = formatDate(date);
+  console.log(formattedDate);
+  expect(formattedDate).toEqual("2022-12-25");
+});

--- a/src/shared/utils/date-utils.ts
+++ b/src/shared/utils/date-utils.ts
@@ -1,0 +1,6 @@
+export function formatDate(date: Date): string {
+  const year = date.getUTCFullYear();
+  const month = ("0" + String(date.getUTCMonth() + 1)).slice(-2);
+  const day = ("0" + String(date.getUTCDate())).slice(-2);
+  return `${year}-${month}-${day}`;
+}

--- a/src/shared/utils/index.ts
+++ b/src/shared/utils/index.ts
@@ -1,2 +1,3 @@
 export * from "./sqs";
 export * from "./s3";
+export * from "./date-utils";


### PR DESCRIPTION
This fixes the bug ticket 215. Athena queries need the date format in yyyy-mm-dd and we were storing the transaction folders as yyyy-m-d which would have been a problem for the first 9 days of the month and first 9 months of the year. 