### PR TITLE
One log bucket for all bucket logs

### DIFF
--- a/cloudformation/athena.yaml
+++ b/cloudformation/athena.yaml
@@ -87,31 +87,12 @@ Resources:
         IgnorePublicAcls: true
         RestrictPublicBuckets: true
       LoggingConfiguration:
-        DestinationBucketName: !Ref AthenaAccessLogBucket
+        DestinationBucketName: !Ref GlobalLogBucket
+        LogFilePrefix: athena-query-results-bucket/log
       LifecycleConfiguration:
         Rules:
           - ExpirationInDays: 7
             Status: Enabled
-
-  AthenaAccessLogBucket:
-    # checkov:skip=CKV_AWS_18: This is the access log bucket - no need for another
-    Type: AWS::S3::Bucket
-    Properties:
-      BucketName:
-        !Join ['-', [!Ref Prefix, !Ref Environment, athena-query-results-logs]]
-      VersioningConfiguration:
-        Status: Enabled
-      AccessControl: LogDeliveryWrite
-      PublicAccessBlockConfiguration:
-        BlockPublicAcls: true
-        BlockPublicPolicy: true
-        IgnorePublicAcls: true
-        RestrictPublicBuckets: true
-      BucketEncryption:
-        ServerSideEncryptionConfiguration:
-          - ServerSideEncryptionByDefault:
-              SSEAlgorithm: aws:kms
-              KMSMasterKeyID: !GetAtt KmsKey.Arn
 
   CalculationDataCrawlerRole:
     Type: AWS::IAM::Role

--- a/cloudformation/calculation.yaml
+++ b/cloudformation/calculation.yaml
@@ -5,7 +5,7 @@ Resources:
   StorageBucket:
     Type: AWS::S3::Bucket
     Properties:
-      BucketName: !Join [ '-', [!Ref Prefix, !Ref Environment, storage ] ]
+      BucketName: !Join ['-', [!Ref Prefix, !Ref Environment, storage]]
       AccessControl: Private
       PublicAccessBlockConfiguration:
         BlockPublicAcls: true
@@ -20,25 +20,5 @@ Resources:
       VersioningConfiguration:
         Status: Enabled
       LoggingConfiguration:
-        DestinationBucketName: !Ref StorageBucketAccessLogsBucket
-        LogFilePrefix: storage-bucket-log
-
-  StorageBucketAccessLogsBucket:
-    # checkov:skip=CKV_AWS_18: This is the access log bucket - no need for another
-    Type: AWS::S3::Bucket
-    Properties:
-      BucketName: !Join [ '-', [!Ref Prefix, !Ref Environment, storage-logs ] ]
-      VersioningConfiguration:
-        Status: Enabled
-      AccessControl: LogDeliveryWrite
-      PublicAccessBlockConfiguration:
-        BlockPublicAcls: true
-        BlockPublicPolicy: true
-        IgnorePublicAcls: true
-        RestrictPublicBuckets: true
-      BucketEncryption:
-        ServerSideEncryptionConfiguration:
-          - ServerSideEncryptionByDefault:
-              SSEAlgorithm: aws:kms
-              KMSMasterKeyID: !GetAtt KmsKey.Arn
-
+        DestinationBucketName: !Ref GlobalLogBucket
+        LogFilePrefix: storage-bucket/log

--- a/cloudformation/config-store.yaml
+++ b/cloudformation/config-store.yaml
@@ -19,28 +19,8 @@ Resources:
       VersioningConfiguration:
         Status: Enabled
       LoggingConfiguration:
-        DestinationBucketName: !Ref ConfigBucketLogBucket
-        LogFilePrefix: config-bucket-log
-
-  ConfigBucketLogBucket:
-    # checkov:skip=CKV_AWS_18: This is the config log bucket - no need for another
-    Type: AWS::S3::Bucket
-    Properties:
-      BucketName:
-        !Join ['-', [!Ref Prefix, !Ref Environment, config-bucket-logs]]
-      VersioningConfiguration:
-        Status: Enabled
-      AccessControl: LogDeliveryWrite
-      PublicAccessBlockConfiguration:
-        BlockPublicAcls: true
-        BlockPublicPolicy: true
-        IgnorePublicAcls: true
-        RestrictPublicBuckets: true
-      BucketEncryption:
-        ServerSideEncryptionConfiguration:
-          - ServerSideEncryptionByDefault:
-              SSEAlgorithm: aws:kms
-              KMSMasterKeyID: !GetAtt KmsKey.Arn
+        DestinationBucketName: !Ref GlobalLogBucket
+        LogFilePrefix: config-bucket/log
 
   # Prices are confidential, so use fake data outside of the production environment
   FakePricesS3Object:

--- a/cloudformation/global.yaml
+++ b/cloudformation/global.yaml
@@ -4,39 +4,79 @@ Resources:
   AlarmTopic:
     Type: AWS::SNS::Topic
     Properties:
-      TopicName: !Join [ '-', [!Ref Prefix, !Ref Environment, alarms] ]
+      TopicName: !Join ['-', [!Ref Prefix, !Ref Environment, alarms]]
       KmsMasterKeyId: !GetAtt KmsKey.Arn
 
   KmsKey:
-      Type: AWS::KMS::Key
-      Properties:
-        EnableKeyRotation: true
-        KeyPolicy:
-          Version: "2012-10-17"
-          Statement:
-            - Effect: Allow
-              Principal:
-                AWS: !Sub arn:aws:iam::${AWS::AccountId}:root
-              Action: kms:*
-              Resource: "*"
-            - Effect: Allow
-              Principal:
-                Service:
-                  - cloudwatch.amazonaws.com
-                  - lambda.amazonaws.com
-                  - s3.amazonaws.com
-                  - sns.amazonaws.com
-                  - sqs.amazonaws.com
-                  - logs.amazonaws.com
-              Action:
-                - kms:Encrypt
-                - kms:Decrypt
-                - kms:GenerateDataKey*
-              Resource: "*"
+    Type: AWS::KMS::Key
+    Properties:
+      EnableKeyRotation: true
+      KeyPolicy:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !Sub arn:aws:iam::${AWS::AccountId}:root
+            Action: kms:*
+            Resource: '*'
+          - Effect: Allow
+            Principal:
+              Service:
+                - cloudwatch.amazonaws.com
+                - lambda.amazonaws.com
+                - s3.amazonaws.com
+                - sns.amazonaws.com
+                - sqs.amazonaws.com
+                - logs.amazonaws.com
+            Action:
+              - kms:Encrypt
+              - kms:Decrypt
+              - kms:GenerateDataKey*
+            Resource: '*'
 
   KmsKeyAlias:
     Type: AWS::KMS::Alias
     Properties:
-      AliasName: !Join [ '-', ['alias/key', !Ref Prefix, !Ref Environment, general] ]
+      AliasName:
+        !Join ['-', ['alias/key', !Ref Prefix, !Ref Environment, general]]
       TargetKeyId: !Ref KmsKey
 
+  GlobalLogBucket:
+    # checkov:skip=CKV_AWS_18: This is the log bucket for all other buckets - no need for a log bucket of the log bucket
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Join ['-', [!Ref Prefix, !Ref Environment, s3-logs]]
+      VersioningConfiguration:
+        Status: Enabled
+      AccessControl: LogDeliveryWrite
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: aws:kms
+              KMSMasterKeyID: !GetAtt KmsKey.Arn
+
+  GlobalAccessLogsBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref GlobalLogBucket
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: EnableS3Logging
+            Effect: Allow
+            Resource:
+              - !Join ['/', [!GetAtt GlobalLogBucket.Arn, '*']]
+            Principal:
+              Service: logging.s3.amazonaws.com
+            Action:
+              - s3:PutObject
+            Condition:
+              StringEquals:
+                aws:SourceAccount: !Ref AWS::AccountId
+              Bool:
+                aws:SecureTransport: true

--- a/cloudformation/raw-invoice-pdf-store.yaml
+++ b/cloudformation/raw-invoice-pdf-store.yaml
@@ -1,10 +1,10 @@
-AWSTemplateFormatVersion: "2010-09-09"
+AWSTemplateFormatVersion: '2010-09-09'
 
 Resources:
   RawInvoicePdfBucket:
     Type: AWS::S3::Bucket
     Properties:
-      BucketName: !Join ["-", [!Ref Prefix, !Ref Environment, raw-invoice-pdf]]
+      BucketName: !Join ['-', [!Ref Prefix, !Ref Environment, raw-invoice-pdf]]
       AccessControl: Private
       PublicAccessBlockConfiguration:
         BlockPublicAcls: true
@@ -19,8 +19,8 @@ Resources:
       VersioningConfiguration:
         Status: Enabled
       LoggingConfiguration:
-        DestinationBucketName: !Ref RawInvoicePdfLogBucket
-        LogFilePrefix: raw-invoice-pdf-bucket-log
+        DestinationBucketName: !Ref GlobalLogBucket
+        LogFilePrefix: raw-invoice-pdf-bucket/log
       NotificationConfiguration:
         QueueConfigurations:
           - Event: s3:ObjectCreated:*
@@ -28,25 +28,5 @@ Resources:
               S3Key:
                 Rules:
                   - Name: suffix
-                    Value: ".pdf"
+                    Value: '.pdf'
             Queue: !GetAtt ExtractQueue.Arn
-
-  RawInvoicePdfLogBucket:
-    # checkov:skip=CKV_AWS_18: This is the raw invoice pdf log bucket - no need for another
-    Type: AWS::S3::Bucket
-    Properties:
-      BucketName:
-        !Join ["-", [!Ref Prefix, !Ref Environment, raw-invoice-pdf-logs]]
-      VersioningConfiguration:
-        Status: Enabled
-      AccessControl: LogDeliveryWrite
-      PublicAccessBlockConfiguration:
-        BlockPublicAcls: true
-        BlockPublicPolicy: true
-        IgnorePublicAcls: true
-        RestrictPublicBuckets: true
-      BucketEncryption:
-        ServerSideEncryptionConfiguration:
-          - ServerSideEncryptionByDefault:
-              SSEAlgorithm: aws:kms
-              KMSMasterKeyID: !GetAtt KmsKey.Arn

--- a/cloudformation/raw-invoice-textract-data-store.yaml
+++ b/cloudformation/raw-invoice-textract-data-store.yaml
@@ -1,4 +1,4 @@
-AWSTemplateFormatVersion: "2010-09-09"
+AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
 
 Resources:
@@ -7,7 +7,7 @@ Resources:
     Properties:
       TopicName:
         !Join [
-          "-",
+          '-',
           [
             !Ref Prefix,
             !Ref Environment,
@@ -27,7 +27,7 @@ Resources:
     Type: AWS::S3::Bucket
     Properties:
       BucketName:
-        !Join ["-", [!Ref Prefix, !Ref Environment, raw-invoice-textract-data]]
+        !Join ['-', [!Ref Prefix, !Ref Environment, raw-invoice-textract-data]]
       AccessControl: Private
       PublicAccessBlockConfiguration:
         BlockPublicAcls: true
@@ -42,15 +42,15 @@ Resources:
       VersioningConfiguration:
         Status: Enabled
       LoggingConfiguration:
-        DestinationBucketName: !Ref RawInvoiceTextractDataLogBucket
-        LogFilePrefix: raw-invoice-textract-data-bucket-log
+        DestinationBucketName: !Ref GlobalLogBucket
+        LogFilePrefix: raw-invoice-textract-data-bucket/log
 
   RawInvoiceTextractDataQueue:
     Type: AWS::SQS::Queue
     Properties:
       QueueName:
         !Join [
-          "-",
+          '-',
           [!Ref Prefix, !Ref Environment, raw-invoice-textract-data-queue],
         ]
 
@@ -64,7 +64,7 @@ Resources:
     Properties:
       QueueName:
         !Join [
-          "-",
+          '-',
           [!Ref Prefix, !Ref Environment, raw-invoice-textract-data-dlq],
         ]
       KmsMasterKeyId: !GetAtt KmsKey.Arn
@@ -79,33 +79,10 @@ Resources:
               ArnEquals:
                 aws:SourceArn: !Ref AmazonTextractRawInvoiceDataTopic
             Effect: Allow
-            Principal: "*"
+            Principal: '*'
             Resource: !GetAtt RawInvoiceTextractDataQueue.Arn
       Queues:
         - !Ref RawInvoiceTextractDataQueue
-
-  RawInvoiceTextractDataLogBucket:
-    # checkov:skip=CKV_AWS_18: This is the log bucket for BTM Data (semi structured store) - no need for another
-    Type: AWS::S3::Bucket
-    Properties:
-      BucketName:
-        !Join [
-          "-",
-          [!Ref Prefix, !Ref Environment, raw-invoice-textract-data-logs],
-        ]
-      VersioningConfiguration:
-        Status: Enabled
-      AccessControl: LogDeliveryWrite
-      PublicAccessBlockConfiguration:
-        BlockPublicAcls: true
-        BlockPublicPolicy: true
-        IgnorePublicAcls: true
-        RestrictPublicBuckets: true
-      BucketEncryption:
-        ServerSideEncryptionConfiguration:
-          - ServerSideEncryptionByDefault:
-              SSEAlgorithm: aws:kms
-              KMSMasterKeyID: !GetAtt KmsKey.Arn
 
   RawInvoiceTextractDataStorageFunction:
     # checkov:skip=CKV_AWS_116: dead letter queue not needed for lambda
@@ -114,7 +91,7 @@ Resources:
     Properties:
       FunctionName:
         !Join [
-          "-",
+          '-',
           [!Ref Prefix, !Ref Environment, raw-textract-storage-function],
         ]
       Environment:
@@ -144,20 +121,20 @@ Resources:
               Resource: !GetAtt KmsKey.Arn
             - Effect: Allow
               Action:
-                - "textract:GetExpenseAnalysis"
-              Resource: "*"
+                - 'textract:GetExpenseAnalysis'
+              Resource: '*'
             - Effect: Allow
               Action:
-                - "s3:DeleteObject"
-                - "s3:GetObject"
-                - "s3:ListBucket"
-                - "s3:PutObject"
+                - 's3:DeleteObject'
+                - 's3:GetObject'
+                - 's3:ListBucket'
+                - 's3:PutObject'
               Resource:
                 - !GetAtt RawInvoicePdfBucket.Arn
-                - !Join ["/", [!GetAtt RawInvoicePdfBucket.Arn, "*"]]
+                - !Join ['/', [!GetAtt RawInvoicePdfBucket.Arn, '*']]
             - Effect: Allow
               Action:
-                - "s3:PutObject"
+                - 's3:PutObject'
               Resource:
-                !Join ["/", [!GetAtt RawInvoiceTextractDataBucket.Arn, "*"]]
+                !Join ['/', [!GetAtt RawInvoiceTextractDataBucket.Arn, '*']]
       ReservedConcurrentExecutions: 10

--- a/cloudformation/test-invoice-pdf-store.yaml
+++ b/cloudformation/test-invoice-pdf-store.yaml
@@ -4,7 +4,7 @@ Resources:
   TestInvoicePdfBucket:
     Type: AWS::S3::Bucket
     Properties:
-      BucketName: !Join [ '-', [!Ref Prefix, !Ref Environment, test-invoice-pdf ] ]
+      BucketName: !Join ['-', [!Ref Prefix, !Ref Environment, test-invoice-pdf]]
       AccessControl: Private
       PublicAccessBlockConfiguration:
         BlockPublicAcls: true
@@ -19,24 +19,5 @@ Resources:
       VersioningConfiguration:
         Status: Enabled
       LoggingConfiguration:
-        DestinationBucketName: !Ref TestInvoicePdfLogBucket
-        LogFilePrefix: test-invoice-pdf-bucket-log
-
-  TestInvoicePdfLogBucket:
-    # checkov:skip=CKV_AWS_18: This is the test invoice pdf log bucket - no need for another
-    Type: AWS::S3::Bucket
-    Properties:
-      BucketName: !Join [ '-', [!Ref Prefix, !Ref Environment, test-invoice-pdf-logs ] ]
-      VersioningConfiguration:
-        Status: Enabled
-      AccessControl: LogDeliveryWrite
-      PublicAccessBlockConfiguration:
-        BlockPublicAcls: true
-        BlockPublicPolicy: true
-        IgnorePublicAcls: true
-        RestrictPublicBuckets: true
-      BucketEncryption:
-        ServerSideEncryptionConfiguration:
-          - ServerSideEncryptionByDefault:
-              SSEAlgorithm: aws:kms
-              KMSMasterKeyID: !GetAtt KmsKey.Arn
+        DestinationBucketName: !Ref GlobalLogBucket
+        LogFilePrefix: test-invoice-pdf-bucket/log

--- a/cloudformation/transaction-storage.yaml
+++ b/cloudformation/transaction-storage.yaml
@@ -1,11 +1,11 @@
-AWSTemplateFormatVersion: "2010-09-09"
+AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
 
 Resources:
   StorageQueue:
     Type: AWS::SQS::Queue
     Properties:
-      QueueName: !Join ["-", [!Ref Prefix, !Ref Environment, storage-queue]]
+      QueueName: !Join ['-', [!Ref Prefix, !Ref Environment, storage-queue]]
       KmsMasterKeyId: !GetAtt KmsKey.Arn
       RedrivePolicy:
         deadLetterTargetArn: !GetAtt StorageDeadLetterQueue.Arn
@@ -14,14 +14,14 @@ Resources:
   StorageDeadLetterQueue:
     Type: AWS::SQS::Queue
     Properties:
-      QueueName: !Join ["-", [!Ref Prefix, !Ref Environment, storage-dlq]]
+      QueueName: !Join ['-', [!Ref Prefix, !Ref Environment, storage-dlq]]
       KmsMasterKeyId: !GetAtt KmsKey.Arn
 
   # Does not seem to work locally: https://github.com/localstack/localstack/issues/7131
   StorageDeadLetterQueueAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmName: !Join ["-", [!Ref Prefix, !Ref Environment, storage-dlq-alarm]]
+      AlarmName: !Join ['-', [!Ref Prefix, !Ref Environment, storage-dlq-alarm]]
       AlarmActions:
         - !Ref AlarmTopic
       ComparisonOperator: GreaterThanThreshold
@@ -43,34 +43,13 @@ Resources:
           ReturnData: true
       Threshold: 0
 
-  StorageBucketAccessLogsBucketPolicy:
-    Type: AWS::S3::BucketPolicy
-    Properties:
-      Bucket: !Ref StorageBucketAccessLogsBucket
-      PolicyDocument:
-        Version: "2012-10-17"
-        Statement:
-          - Sid: EnableS3Logging
-            Effect: Allow
-            Resource:
-              - !Join ["/", [!GetAtt StorageBucketAccessLogsBucket.Arn, "*"]]
-            Principal:
-              Service: logging.s3.amazonaws.com
-            Action:
-              - s3:PutObject
-            Condition:
-              StringEquals:
-                aws:SourceAccount: !Ref AWS::AccountId
-              Bool:
-                aws:SecureTransport: true
-
   StorageFunction:
     # checkov:skip=CKV_AWS_116: DLQ not needed for lambda driven by SQS
     # checkov:skip=CKV_AWS_117: VPC not needed for lambda
     Type: AWS::Serverless::Function
     Properties:
       FunctionName:
-        !Join ["-", [!Ref Prefix, !Ref Environment, storage-function]]
+        !Join ['-', [!Ref Prefix, !Ref Environment, storage-function]]
       Events:
         StorageEvent:
           Type: SQS
@@ -84,7 +63,7 @@ Resources:
           STORAGE_BUCKET: !Ref StorageBucket
           TRANSACTIONS_FOLDER: 'btm_transactions'
           LOCAL_ENDPOINT:
-            !If [IsLocal, "http://s3.localhost.localstack.cloud:4566", ""]
+            !If [IsLocal, 'http://s3.localhost.localstack.cloud:4566', '']
       Handler: storeTransactions.handler
       Policies:
         - AWSLambdaBasicExecutionRole
@@ -107,14 +86,14 @@ Resources:
                 - s3:GetObject
                 - s3:PutObject
               Resource:
-                - !Join ["/", [!GetAtt StorageBucket.Arn, "*"]]
+                - !Join ['/', [!GetAtt StorageBucket.Arn, '*']]
       ReservedConcurrentExecutions: 10
 
   StorageFunctionAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName:
-        !Join ["-", [!Ref Prefix, !Ref Environment, storage-function-alarm]]
+        !Join ['-', [!Ref Prefix, !Ref Environment, storage-function-alarm]]
       AlarmActions:
         - !Ref AlarmTopic
       ComparisonOperator: GreaterThanThreshold

--- a/cloudformation/validated-invoice-data-store.yaml
+++ b/cloudformation/validated-invoice-data-store.yaml
@@ -4,7 +4,8 @@ Resources:
   ValidatedInvoiceDataBucket:
     Type: AWS::S3::Bucket
     Properties:
-      BucketName: !Join [ '-', [!Ref Prefix, !Ref Environment, validated-invoice-data ] ]
+      BucketName:
+        !Join ['-', [!Ref Prefix, !Ref Environment, validated-invoice-data]]
       AccessControl: Private
       PublicAccessBlockConfiguration:
         BlockPublicAcls: true
@@ -19,24 +20,5 @@ Resources:
       VersioningConfiguration:
         Status: Enabled
       LoggingConfiguration:
-        DestinationBucketName: !Ref ValidatedInvoiceDataLogBucket
-        LogFilePrefix: validated-invoice-data-bucket-log
-
-  ValidatedInvoiceDataLogBucket:
-    # checkov:skip=CKV_AWS_18: This is the log bucket for the validated invoice data - no need for another
-    Type: AWS::S3::Bucket
-    Properties:
-      BucketName: !Join [ '-', [!Ref Prefix, !Ref Environment, validated-invoice-data-logs ] ]
-      VersioningConfiguration:
-        Status: Enabled
-      AccessControl: LogDeliveryWrite
-      PublicAccessBlockConfiguration:
-        BlockPublicAcls: true
-        BlockPublicPolicy: true
-        IgnorePublicAcls: true
-        RestrictPublicBuckets: true
-      BucketEncryption:
-        ServerSideEncryptionConfiguration:
-          - ServerSideEncryptionByDefault:
-              SSEAlgorithm: aws:kms
-              KMSMasterKeyID: !GetAtt KmsKey.Arn
+        DestinationBucketName: !Ref GlobalLogBucket
+        LogFilePrefix: validated-invoice-data-bucket/log


### PR DESCRIPTION
Use only one global log bucket for all the S3-logs, the individual logs from the buckets go into sub-folders.

This will break the deployment when merged as the old log buckets will likely not be empty at this point. I'll fix it when it happens.