### PR TITLE
BTM-321: helpers for mocked invoices

### DIFF
--- a/integration_tests/helpers/mock-data/invoice/random.ts
+++ b/integration_tests/helpers/mock-data/invoice/random.ts
@@ -9,7 +9,13 @@ export interface InvoiceOptions {
   date?: Date;
   dueDate?: Date;
   invoiceNumber?: string;
+  lineItemCount?: number;
+  lineItemOptions?: LineItemOptions;
   lineItems?: LineItem[];
+}
+
+export interface LineItemOptions extends Partial<LineItem> {
+  vatRate?: number;
 }
 
 const randomLetter = (): string => {
@@ -62,7 +68,7 @@ const randomCustomer = (): Customer => {
   };
 };
 
-export const randomLineItem = (options?: Partial<LineItem>): LineItem => {
+export const randomLineItem = (options?: LineItemOptions): LineItem => {
   const priceTier = [
     { min: 0, max: 5, unitPrice: 6.5 },
     { min: 6, max: 10, unitPrice: 0.25 },
@@ -73,22 +79,28 @@ export const randomLineItem = (options?: Partial<LineItem>): LineItem => {
     priceTier.min + Math.floor(Math.random() * (priceTier.max ?? 20));
   const unitPrice = options?.unitPrice ?? priceTier.unitPrice;
   const subtotal = options?.subtotal ?? quantity * unitPrice;
+  const vatRate = options?.vatRate ?? 0.2;
   return {
     description:
       options?.description ??
       "Verification of sentience via address checking mechanism", // should match IPV_ADDRESS_CRI_END from fake-vendor-services.csv
-    vat: options?.vat ?? 0.2 * subtotal,
+    vat: options?.vat ?? vatRate * subtotal,
     quantity,
     unitPrice,
     subtotal,
   };
 };
 
-const randomLineItems = (quantity: number): LineItem[] => {
-  return new Array(quantity).fill(null).map(() => randomLineItem());
+const randomLineItems = (
+  quantity: number,
+  options?: LineItemOptions
+): LineItem[] => {
+  return new Array(quantity).fill(null).map(() => randomLineItem(options));
 };
 
 export const randomInvoice = (options?: InvoiceOptions): Invoice => {
+  const lineItemCount = options?.lineItemCount ?? 10;
+
   return new Invoice({
     vendor: {
       ...randomVendor(),
@@ -105,6 +117,8 @@ export const randomInvoice = (options?: InvoiceOptions): Invoice => {
     dueDate:
       options?.dueDate ??
       new Date(new Date().getTime() + 1000 * 60 * 60 * 24 * 30),
-    lineItems: options?.lineItems ?? randomLineItems(10),
+    lineItems:
+      options?.lineItems ??
+      randomLineItems(lineItemCount, options?.lineItemOptions),
   });
 };


### PR DESCRIPTION
This adds code for integration tests that can help to create matching invoices and transactions.

Specifically, this adds one function and updates two others:
- `getVendorServiceConfigRow`: added to fetch vendor-service config from the private repo
- `randomLineItem` and `randomInvoice`: updated to allow some non-random fields

Here is an example of how to create an invoice and transactions with matching vendor, transaction quantity, and event names:
```ts
import {
  makeMockInvoicePDF,
  randomInvoice,
  randomLineItem,
  writeInvoiceToS3,
} from "../helpers/mock-data/invoice";
import {
  generatePublishAndValidateEvents,
  TimeStamps,
} from "../helpers/commonHelpers";
import { getVendorServiceConfigRow } from "../helpers/configHelpers";
import { ClientId, EventName } from "../payloads/snsEventPayload";

describe("testing", () => {
  test("testing", async () => {
    const givenClientId = ClientId.client1;
    const givenEventName = EventName.IPV_PASSPORT_CRI_REQUEST_SENT;
    const givenQuantity = 10;

    const { service_name: givenServiceName, vendor_name: givenVendorName } =
      await getVendorServiceConfigRow({
        client_id: givenClientId,
        event_name: givenEventName,
      });

    const givenLineItem = randomLineItem({
      description: givenServiceName,
      quantity: givenQuantity,
    });

    const givenInvoice = randomInvoice({
      vendor: {
        name: givenVendorName,
      },
      lineItems: [givenLineItem],
    });

    await Promise.all([
      generatePublishAndValidateEvents({
        numberOfTestEvents: givenQuantity,
        eventName: givenEventName,
        clientId: givenClientId,
        eventTime: TimeStamps.CURRENT_TIME,
      }),
      makeMockInvoicePDF(writeInvoiceToS3)(givenInvoice),
    ]);

    // Check the results
  });
});
```