### PR TITLE
BTM-346: publish unit tests on push to main branch

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     # Every day, 3 times daily, at 9AM, 1PM and 4PM.
     - cron: '0 9,13,16 * * 1-5'
-  pull_request:
+  push:
     branches:
       - main
 


### PR DESCRIPTION
This fixes the unit test running and publishing so it happens when a pull request gets merged instead of when one gets opened