### PR TITLE
BTM-348: fix integration tests

### DIFF
--- a/integration_tests/Dockerfile
+++ b/integration_tests/Dockerfile
@@ -42,6 +42,7 @@ WORKDIR /test-app
 COPY package.json package-lock.json tsconfig.json jest.integration.config.ts ./
 COPY integration_tests ./integration_tests
 COPY src/handlers/int-test-support/ ./src/handlers/int-test-support/
+COPY src/shared/ ./src/shared/
 
 RUN npm ci
 


### PR DESCRIPTION
This (hopefully) fixes tests that run in the AWS deployment pipeline that are failing. The failures seem to be caused by an `import` of a file that was not being copied to the Docker container from which the tests are triggered