### PR TITLE
Improve int test helper types

### DIFF
--- a/src/handlers/int-test-support/handler.test.ts
+++ b/src/handlers/int-test-support/handler.test.ts
@@ -1,5 +1,5 @@
 import { Context } from "aws-lambda";
-import { handler, TestSupportEvent } from "./handler";
+import { handler, IntTestHelpers, TestSupportEvent } from "./handler";
 import { getS3Object, listS3Objects } from "./helpers/s3Helper";
 
 jest.mock("./helpers/s3Helper.ts");
@@ -33,7 +33,7 @@ describe("Handler test for integration test support function", () => {
     inputEvent = {
       environment: "test-env",
       config: "test-config",
-      command: "getS3Object",
+      command: IntTestHelpers.getS3Object,
       parameters: { some: "parameter" },
     };
 
@@ -48,7 +48,7 @@ describe("Handler test for integration test support function", () => {
     inputEvent = {
       environment: "test-env",
       config: "test-config",
-      command: "listS3Objects",
+      command: IntTestHelpers.listS3Objects,
       parameters: { some: "parameter" },
     };
 
@@ -63,7 +63,7 @@ describe("Handler test for integration test support function", () => {
     inputEvent = {
       environment: "test-env",
       config: "test-config",
-      command: "someUnknownCommand",
+      command: "someUnknownCommand" as unknown as IntTestHelpers,
       parameters: { some: "parameter" },
     };
 

--- a/src/handlers/int-test-support/handler.ts
+++ b/src/handlers/int-test-support/handler.ts
@@ -33,20 +33,20 @@ export interface TestSupportReturn {
 }
 
 export enum IntTestHelpers {
-  getS3Object,
-  getS3Objects,
-  listS3Objects,
-  putS3Object,
-  deleteS3Object,
-  deleteS3Objects,
-  checkIfS3ObjectExists,
-  publishToTestTopic,
-  checkGivenStringExistsInLogs,
-  getRecentCloudwatchLogs,
-  startQueryExecutionCommand,
-  getQueryExecutionStatus,
-  getQueryResults,
-  createInvoiceInS3,
+  getS3Object = "getS3Object",
+  getS3Objects = "getS3Objects",
+  listS3Objects = "listS3Objects",
+  putS3Object = "putS3Object",
+  deleteS3Object = "deleteS3Object",
+  deleteS3Objects = "deleteS3Objects",
+  checkIfS3ObjectExists = "checkIfS3ObjectExists",
+  publishToTestTopic = "publishToTestTopic",
+  checkGivenStringExistsInLogs = "checkGivenStringExistsInLogs",
+  getRecentCloudwatchLogs = "getRecentCloudwatchLogs",
+  startQueryExecutionCommand = "startQueryExecutionCommand",
+  getQueryExecutionStatus = "getQueryExecutionStatus",
+  getQueryResults = "getQueryResults",
+  createInvoiceInS3 = "createInvoiceInS3",
 }
 
 export interface HelperDict {

--- a/src/handlers/int-test-support/handler.ts
+++ b/src/handlers/int-test-support/handler.ts
@@ -23,7 +23,7 @@ import { createInvoiceInS3 } from "./helpers/mock-data/invoice/helpers";
 export interface TestSupportEvent {
   environment: string;
   config: string;
-  command: string;
+  command: IntTestHelpers;
   parameters: any;
 }
 
@@ -32,7 +32,7 @@ export interface TestSupportReturn {
   successObject?: any;
 }
 
-const functionMap: { [name: string]: Function } = {
+export enum IntTestHelpers {
   getS3Object,
   getS3Objects,
   listS3Objects,
@@ -47,9 +47,46 @@ const functionMap: { [name: string]: Function } = {
   getQueryExecutionStatus,
   getQueryResults,
   createInvoiceInS3,
+}
+
+export interface HelperDict {
+  [IntTestHelpers.getS3Object]: typeof getS3Object;
+  [IntTestHelpers.getS3Objects]: typeof getS3Objects;
+  [IntTestHelpers.listS3Objects]: typeof listS3Objects;
+  [IntTestHelpers.putS3Object]: typeof putS3Object;
+  [IntTestHelpers.deleteS3Object]: typeof deleteS3Object;
+  [IntTestHelpers.deleteS3Objects]: typeof deleteS3Objects;
+  [IntTestHelpers.checkIfS3ObjectExists]: typeof checkIfS3ObjectExists;
+  [IntTestHelpers.publishToTestTopic]: typeof publishToTestTopic;
+  [IntTestHelpers.checkGivenStringExistsInLogs]: typeof checkGivenStringExistsInLogs;
+  [IntTestHelpers.getRecentCloudwatchLogs]: typeof getRecentCloudwatchLogs;
+  [IntTestHelpers.startQueryExecutionCommand]: typeof startQueryExecutionCommand;
+  [IntTestHelpers.getQueryExecutionStatus]: typeof getQueryExecutionStatus;
+  [IntTestHelpers.getQueryResults]: typeof getQueryResults;
+  [IntTestHelpers.createInvoiceInS3]: typeof createInvoiceInS3;
+}
+
+const functionMap: HelperDict = {
+  [IntTestHelpers.getS3Object]: getS3Object,
+  [IntTestHelpers.getS3Objects]: getS3Objects,
+  [IntTestHelpers.listS3Objects]: listS3Objects,
+  [IntTestHelpers.putS3Object]: putS3Object,
+  [IntTestHelpers.deleteS3Object]: deleteS3Object,
+  [IntTestHelpers.deleteS3Objects]: deleteS3Objects,
+  [IntTestHelpers.checkIfS3ObjectExists]: checkIfS3ObjectExists,
+  [IntTestHelpers.publishToTestTopic]: publishToTestTopic,
+  [IntTestHelpers.checkGivenStringExistsInLogs]: checkGivenStringExistsInLogs,
+  [IntTestHelpers.getRecentCloudwatchLogs]: getRecentCloudwatchLogs,
+  [IntTestHelpers.startQueryExecutionCommand]: startQueryExecutionCommand,
+  [IntTestHelpers.getQueryExecutionStatus]: getQueryExecutionStatus,
+  [IntTestHelpers.getQueryResults]: getQueryResults,
+  [IntTestHelpers.createInvoiceInS3]: createInvoiceInS3,
 };
 
-const callFunction = async (name: string, parameters: any): Promise<any> => {
+const callFunction = async (
+  name: IntTestHelpers,
+  parameters: any
+): Promise<any> => {
   if (functionMap[name] !== undefined) {
     const func: Function = functionMap[name];
     const ret = await func(parameters);

--- a/src/handlers/int-test-support/helpers/athenaHelper.ts
+++ b/src/handlers/int-test-support/helpers/athenaHelper.ts
@@ -10,6 +10,7 @@ import { waitForTrue } from "./commonHelpers";
 import { resourcePrefix, runViaLambda } from "./envHelper";
 import { athenaClient } from "../clients";
 import { sendLambdaCommand } from "./lambdaHelper";
+import { IntTestHelpers } from "../handler";
 
 interface StringObject {
   [key: string]: string;
@@ -24,7 +25,10 @@ const startQueryExecutionCommand = async (
   query: DatabaseQuery
 ): Promise<string> => {
   if (runViaLambda())
-    return await sendLambdaCommand("startQueryExecutionCommand", query);
+    return await sendLambdaCommand(
+      IntTestHelpers.startQueryExecutionCommand,
+      query
+    );
   const params = {
     QueryExecutionContext: {
       Database: query.databaseName,
@@ -44,7 +48,7 @@ const getQueryExecutionStatus = async (
 ): Promise<QueryExecutionStatus | undefined> => {
   if (runViaLambda())
     return (await sendLambdaCommand(
-      "getQueryExecutionStatus",
+      IntTestHelpers.getQueryExecutionStatus,
       queryId
     )) as QueryExecutionStatus;
   const params = {
@@ -62,7 +66,7 @@ const getQueryResults = async (
 ): Promise<GetQueryResultsCommandOutput | undefined> => {
   if (runViaLambda())
     return (await sendLambdaCommand(
-      "getQueryResults",
+      IntTestHelpers.getQueryResults,
       queryId
     )) as unknown as GetQueryResultsCommandOutput;
 

--- a/src/handlers/int-test-support/helpers/cloudWatchHelper.ts
+++ b/src/handlers/int-test-support/helpers/cloudWatchHelper.ts
@@ -7,6 +7,7 @@ import {
 import { runViaLambda } from "./envHelper";
 import { cloudWatchLogsClient } from "../clients";
 import { sendLambdaCommand } from "./lambdaHelper";
+import { IntTestHelpers } from "../handler";
 
 interface LogCheckParameters {
   logName: string;
@@ -19,7 +20,7 @@ export async function getRecentCloudwatchLogs(params: {
 }): Promise<FilterLogEventsCommandOutput> {
   if (runViaLambda()) {
     return (await sendLambdaCommand(
-      "getRecentCloudwatchLogs",
+      IntTestHelpers.getRecentCloudwatchLogs,
       params
     )) as unknown as FilterLogEventsCommandOutput;
   }
@@ -39,7 +40,7 @@ async function checkGivenStringExistsInLogs(
 ): Promise<boolean> {
   if (runViaLambda())
     return (await sendLambdaCommand(
-      "checkGivenStringExistsInLogs",
+      IntTestHelpers.checkGivenStringExistsInLogs,
       params
     )) as unknown as boolean;
   const commandInput: FilterLogEventsCommandInput = {

--- a/src/handlers/int-test-support/helpers/lambdaHelper.ts
+++ b/src/handlers/int-test-support/helpers/lambdaHelper.ts
@@ -1,11 +1,12 @@
 import { InvokeCommand, InvokeCommandInput } from "@aws-sdk/client-lambda";
 import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
 import { lambdaClient } from "../clients";
+import { HelperDict, IntTestHelpers } from "../handler";
 import { configName, envName, resourcePrefix } from "./envHelper";
 
-export const sendLambdaCommand = async (
-  command: string,
-  parameters: any
+export const sendLambdaCommand = async <THelper extends IntTestHelpers>(
+  command: THelper,
+  parameters: Parameters<HelperDict[THelper]>[0]
 ): Promise<string> => {
   const commandInput: InvokeCommandInput = {
     FunctionName: `${resourcePrefix()}-int-test-support-function`,

--- a/src/handlers/int-test-support/helpers/mock-data/invoice/helpers.ts
+++ b/src/handlers/int-test-support/helpers/mock-data/invoice/helpers.ts
@@ -5,6 +5,7 @@ import { configStackName, runViaLambda } from "../../envHelper";
 import { sendLambdaCommand } from "../../lambdaHelper";
 import { getVendorServiceConfigRow } from "../../../../../shared/utils/config-utils";
 import { InvoiceData } from "./types";
+import { IntTestHelpers } from "../../../handler";
 
 interface InvoiceDataAndFileName {
   invoiceData: InvoiceData;
@@ -16,7 +17,7 @@ export const createInvoiceInS3 = async (
 ): Promise<S3Object> => {
   if (runViaLambda())
     return (await sendLambdaCommand(
-      "createInvoiceInS3",
+      IntTestHelpers.createInvoiceInS3,
       params
     )) as unknown as S3Object;
 

--- a/src/handlers/int-test-support/helpers/s3Helper.ts
+++ b/src/handlers/int-test-support/helpers/s3Helper.ts
@@ -14,6 +14,7 @@ import {
 import { runViaLambda } from "./envHelper";
 import { s3Client } from "../clients";
 import { sendLambdaCommand } from "./lambdaHelper";
+import { IntTestHelpers } from "../handler";
 
 interface S3Object {
   bucket: string;
@@ -35,7 +36,7 @@ const listS3Objects = async (
 ): Promise<ListObjectsCommandOutput> => {
   if (runViaLambda())
     return (await sendLambdaCommand(
-      "listS3Objects",
+      IntTestHelpers.listS3Objects,
       params
     )) as unknown as ListObjectsCommandOutput;
 
@@ -48,7 +49,8 @@ const listS3Objects = async (
 };
 
 const getS3Object = async (object: S3Object): Promise<string | undefined> => {
-  if (runViaLambda()) return await sendLambdaCommand("getS3Object", object);
+  if (runViaLambda())
+    return await sendLambdaCommand(IntTestHelpers.getS3Object, object);
 
   const bucketParams = {
     Bucket: object.bucket,
@@ -69,7 +71,7 @@ const putS3Object = async (
 ): Promise<PutObjectCommandOutput> => {
   if (runViaLambda())
     return (await sendLambdaCommand(
-      "putS3Object",
+      IntTestHelpers.putS3Object,
       dataAndTarget
     )) as unknown as PutObjectCommandOutput;
 
@@ -86,7 +88,7 @@ const deleteS3Object = async (
 ): Promise<DeleteObjectCommandOutput> => {
   if (runViaLambda())
     return (await sendLambdaCommand(
-      "deleteS3Object",
+      IntTestHelpers.deleteS3Object,
       object
     )) as unknown as DeleteObjectCommandOutput;
 
@@ -102,7 +104,7 @@ const deleteS3Objects = async (
 ): Promise<DeleteObjectCommandOutput[]> => {
   if (runViaLambda())
     return (await sendLambdaCommand(
-      "deleteS3Objects",
+      IntTestHelpers.deleteS3Objects,
       params
     )) as unknown as DeleteObjectCommandOutput[];
 
@@ -134,7 +136,7 @@ const copyObject = async (
 const checkIfS3ObjectExists = async (object: S3Object): Promise<boolean> => {
   if (runViaLambda())
     return (await sendLambdaCommand(
-      "checkIfS3ObjectExists",
+      IntTestHelpers.checkIfS3ObjectExists,
       object
     )) as unknown as boolean;
 
@@ -155,7 +157,7 @@ const checkIfS3ObjectExists = async (object: S3Object): Promise<boolean> => {
 const getS3Objects = async (params: BucketAndPrefix): Promise<string[]> => {
   if (runViaLambda())
     return (await sendLambdaCommand(
-      "getS3Objects",
+      IntTestHelpers.getS3Objects,
       params
     )) as unknown as string[];
 

--- a/src/handlers/int-test-support/helpers/snsHelper.ts
+++ b/src/handlers/int-test-support/helpers/snsHelper.ts
@@ -8,6 +8,7 @@ import { resourcePrefix, runViaLambda } from "./envHelper";
 import { snsClient } from "../clients";
 import { sendLambdaCommand } from "./lambdaHelper";
 import NodeCache from "node-cache";
+import { IntTestHelpers } from "../handler";
 
 let snsParams: PublishInput;
 
@@ -40,7 +41,7 @@ export const publishToTestTopic = async (
 ): Promise<PublishCommandOutput> => {
   if (runViaLambda())
     return (await sendLambdaCommand(
-      "publishToTestTopic",
+      IntTestHelpers.publishToTestTopic,
       payload
     )) as unknown as PublishCommandOutput;
   snsParams = await snsParameters(payload);


### PR DESCRIPTION
The other day we had a weird issue where tests in the pipeline were producing different results to tests run locally. When an invoice was generated and uploaded to S3 in the pipeline it would be called undefined.json. This was happening because the signature of the `createInvoiceInS3` function had been changed to allow passing in a filename. We didn't pick up on this being a problem because `sendLambdaCommand` didn't preserve the types of the helpers it invoked. With this change it will discern the helper you're asking for the invocation of and give you a nudge if the args you've passed in don't match what it's expecting.