### PR TITLE
BTM-395: Textract dead-letter queue

### DIFF
--- a/cloudformation/raw-invoice-textract-data-store.yaml
+++ b/cloudformation/raw-invoice-textract-data-store.yaml
@@ -14,6 +14,29 @@ Resources:
       Endpoint: !GetAtt RawInvoiceTextractDataQueue.Arn
       Protocol: sqs
       TopicArn: !Ref AmazonTextractRawInvoiceDataTopic
+      RedrivePolicy:
+        deadLetterTargetArn: !GetAtt AmazonTextractRawInvoiceDataTopicSubscriptionDeadLetterQueue.Arn
+
+  AmazonTextractRawInvoiceDataTopicSubscriptionDeadLetterQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: !Sub ${AWS::StackName}-amazon-textract-raw-invoice-data-dlq
+      KmsMasterKeyId: !GetAtt KmsKey.Arn
+
+  AmazonTextractRawInvoiceDataTopicSubscriptionDeadLetterQueuePolicy:
+    Type: AWS::SQS::QueuePolicy
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action: SQS:SendMessage
+            Condition:
+              ArnEquals:
+                aws:SourceArn: !Ref AmazonTextractRawInvoiceDataTopic
+            Effect: Allow
+            Principal: '*'
+            Resource: !GetAtt AmazonTextractRawInvoiceDataTopicSubscriptionDeadLetterQueue.Arn
+      Queues:
+        - !Ref AmazonTextractRawInvoiceDataTopicSubscriptionDeadLetterQueue
 
   RawInvoiceTextractDataBucket:
     Type: AWS::S3::Bucket


### PR DESCRIPTION
This adds a queue where Textract notifications go if they cannot reach the Textract storage queue

This has been manually tested but has no automated test, to avoid altering the CloudFormation deployment to prevent notifications reaching the Textract storage queue