### PR TITLE
BTM-371: use vendor ID instead of name

### DIFF
--- a/cloudformation/calculation-athena.yaml
+++ b/cloudformation/calculation-athena.yaml
@@ -169,14 +169,15 @@ Resources:
                             AND (txn.vendor_id = rates.vendor_id)
                             AND (txn.month_event_count BETWEEN rates.volumes_from AND COALESCE(rates.volumes_to, 9999999))
                             AND (txn.timestamp BETWEEN rates.effective_from AND COALESCE(rates.effective_to, "From_iso8601_timestamp"('2049-12-31')))))
-          SELECT "MAX"(vendor_name)      vendor_name,
+          SELECT "MAX"(vendor_id)        vendor_id,
+                "MAX"(vendor_name)       vendor_name,
                 "MAX"(service_name)      service_name,
                 "SUM"(transaction_price) price,
                 "COUNT"(event_id)        quantity,
                 month,
                 year
           FROM   btm_transactions_harmonised
-          GROUP  BY vendor_name,
+          GROUP  BY vendor_id,
                     service_name,
                     year,
                     month
@@ -185,7 +186,9 @@ Resources:
 
   BillingAndTransactionsCuratedView:
     Type: Custom::AthenaView
-    DependsOn: TransactionsCuratedView
+    DependsOn:
+      - InvoiceLineItemView
+      - TransactionsCuratedView
     Properties:
       ServiceToken: !GetAtt CustomAthenaViewResourceFunction.Arn
       View:
@@ -193,7 +196,8 @@ Resources:
         Name: btm_billing_and_transactions_curated
         Query: !Sub |
           SELECT
-            COALESCE(invoice.vendor_name, txn.vendor_name) vendor_name
+            COALESCE(invoice.vendor_id, txn.vendor_id) vendor_id
+            , COALESCE(invoice.vendor_name, txn.vendor_name) vendor_name
             , COALESCE(invoice.service_name, txn.service_name) service_name
             , COALESCE(invoice.year, txn.year) year
             , COALESCE(invoice.month, txn.month) month
@@ -215,7 +219,7 @@ Resources:
                 ELSE (CASE WHEN (COALESCE(txn.price, 0) = 0) THEN (CASE WHEN (COALESCE(invoice.price, 0) = 0) THEN 0 ELSE null END) ELSE ((100 * (COALESCE(invoice.price, 0) - txn.price)) / txn.price) END) END) Difference
           FROM
             (btm_transactions_curated txn
-            FULL JOIN btm_billing_curated invoice ON ((((txn.vendor_name = invoice.vendor_name) AND (txn.service_name = invoice.service_name)) AND (txn.year = invoice.year)) AND (txn.month = invoice.month)))
+            FULL JOIN btm_billing_curated invoice ON ((((txn.vendor_id = invoice.vendor_id) AND (txn.service_name = invoice.service_name)) AND (txn.year = invoice.year)) AND (txn.month = invoice.month)))
         Workgroup: !Ref AthenaTransactionWorkgroup
 
   AthenaTransactionWorkgroup:

--- a/cloudformation/invoice-athena.yaml
+++ b/cloudformation/invoice-athena.yaml
@@ -52,6 +52,8 @@ Resources:
           Columns:
             - Name: invoice_receipt_id
               Type: string
+            - Name: vendor_id
+              Type: string
             - Name: vendor_name
               Type: string
             - Name: total
@@ -99,6 +101,7 @@ Resources:
         Name: btm_billing_curated
         Query: |
           SELECT 
+            vendor_id,
             vendor_name,
             service_name,
             sum(quantity) AS quantity,
@@ -113,5 +116,5 @@ Resources:
               date_format(invoice_receipt_date,'%Y') AS year
             FROM btm_billing_standardised
           )
-          GROUP BY vendor_name,service_name,year,month
+          GROUP BY vendor_id,vendor_name,service_name,year,month
         Workgroup: !Ref AthenaInvoiceWorkgroup

--- a/integration_tests/tests/billing-and-transaction-view-tests.ts
+++ b/integration_tests/tests/billing-and-transaction-view-tests.ts
@@ -102,6 +102,7 @@ export const createInvoice = async ({
 
   const givenInvoice = randomInvoice({
     vendor: {
+      id: vendorId,
       name: prettyVendorNameMap[vendorId],
     },
     date: new Date(eventTimeStamp[eventTime] * 1000),
@@ -176,6 +177,7 @@ export const assertResultsWithTestData = async ({
 };
 
 type BillingTransactionCurated = Array<{
+  vendor_id: string;
   vendor_name: string;
   service_name: string;
   year: string;

--- a/integration_tests/tests/s3-invoice-end-to-end-tests.ts
+++ b/integration_tests/tests/s3-invoice-end-to-end-tests.ts
@@ -87,7 +87,7 @@ describe("\n Happy path - Upload valid mock invoice pdf and verify data is seen 
 
     // Check the view results match the invoice.
     const queryString =
-      'SELECT * FROM "btm_billing_curated" ORDER BY vendor_name DESC, year DESC';
+      'SELECT * FROM "btm_billing_curated" ORDER BY vendor_id DESC, year DESC';
     const queryId = await startQueryExecutionCommand({
       databaseName,
       queryString,
@@ -98,6 +98,7 @@ describe("\n Happy path - Upload valid mock invoice pdf and verify data is seen 
       return q0.service_name.localeCompare(q1.service_name);
     });
     for (let i = 0; i < queryObjects.length; i++) {
+      expect(invoice.vendor.id).toEqual(queryObjects[i].vendor_id);
       expect(invoice.vendor.name).toEqual(queryObjects[i].vendor_name);
       expect(expectedServices[i]).toEqual(queryObjects[i].service_name);
       expect(invoice.date.getFullYear()).toEqual(+queryObjects[i].year);
@@ -135,6 +136,7 @@ describe("\n Happy path - Upload valid mock invoice pdf and verify data is seen 
 });
 
 interface BillingCurated {
+  vendor_id: string;
   vendor_name: string;
   service_name: string;
   quantity: number;

--- a/integration_tests/tests/transaction-view-athena-tests.ts
+++ b/integration_tests/tests/transaction-view-athena-tests.ts
@@ -65,6 +65,7 @@ describe("\nExecute athena transaction curated query to retrieve price \n", () =
 });
 
 interface TransactionCuratedView {
+  vendor_id: string;
   vendor_name: string;
   service_name: string;
   price: number;

--- a/src/handlers/int-test-support/helpers/mock-data/invoice/helpers.ts
+++ b/src/handlers/int-test-support/helpers/mock-data/invoice/helpers.ts
@@ -1,9 +1,8 @@
 import { S3Object } from "../../s3Helper";
 import { Invoice, makeMockInvoicePDF } from "./invoice";
 import { writeInvoiceToS3 } from "./writers";
-import { configStackName, runViaLambda } from "../../envHelper";
+import { runViaLambda } from "../../envHelper";
 import { sendLambdaCommand } from "../../lambdaHelper";
-import { getVendorServiceConfigRow } from "../../../../../shared/utils/config-utils";
 import { InvoiceData } from "./types";
 import { IntTestHelpers } from "../../../handler";
 
@@ -23,13 +22,9 @@ export const createInvoiceInS3 = async (
 
   const invoice = new Invoice(params.invoiceData);
 
-  const { vendor_id: vendorId } = await getVendorServiceConfigRow(
-    configStackName(),
-    { vendor_name: invoice.vendor.name }
-  );
   return await makeMockInvoicePDF(writeInvoiceToS3)(
     invoice,
-    vendorId,
+    invoice.vendor.id,
     params.filename
   );
 };

--- a/src/handlers/int-test-support/helpers/mock-data/invoice/random.ts
+++ b/src/handlers/int-test-support/helpers/mock-data/invoice/random.ts
@@ -55,6 +55,7 @@ const randomAddress = (): string[] => {
 
 const randomVendor = (): Vendor => {
   return {
+    id: "vendor_testvendor3",
     name: "Vendor Three",
     vatNumber: `GB${Math.floor(Math.random() * 1_000_000_000)}`,
     address: randomAddress(),

--- a/src/handlers/int-test-support/helpers/mock-data/invoice/types.ts
+++ b/src/handlers/int-test-support/helpers/mock-data/invoice/types.ts
@@ -7,6 +7,7 @@ export interface LineItem {
 }
 
 export interface Vendor {
+  id: string;
   name: string;
   address: string[];
   vatNumber: string;

--- a/src/handlers/int-test-support/helpers/queryHelper.ts
+++ b/src/handlers/int-test-support/helpers/queryHelper.ts
@@ -1,9 +1,4 @@
-import {
-  VendorId,
-  EventName,
-  prettyVendorNameMap,
-  prettyEventNameMap,
-} from "./payloadHelper";
+import { VendorId, EventName, prettyEventNameMap } from "./payloadHelper";
 import { queryObject, startQueryExecutionCommand } from "./athenaHelper";
 import { TableNames } from "./commonHelpers";
 import { resourcePrefix } from "./envHelper";
@@ -22,11 +17,10 @@ export const queryResponseFilterByVendorServiceNameYear = async ({
   tableName: TableNames;
   year: number;
 }): Promise<[]> => {
-  const prettyVendorName = prettyVendorNameMap[vendorId];
   const prettyEventName = prettyEventNameMap[eventName];
 
   // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-  const curatedQueryString = `SELECT * FROM "${tableName}" WHERE vendor_name='${prettyVendorName}' AND service_name='${prettyEventName}' AND year='${year}'`;
+  const curatedQueryString = `SELECT * FROM "${tableName}" WHERE vendor_id='${vendorId}' AND service_name='${prettyEventName}' AND year='${year}'`;
   const queryId = await startQueryExecutionCommand({
     databaseName,
     queryString: curatedQueryString,

--- a/src/handlers/store-standardised-invoices/get-standardised-invoice/get-standardised-invoice-0.test.ts
+++ b/src/handlers/store-standardised-invoices/get-standardised-invoice/get-standardised-invoice-0.test.ts
@@ -379,6 +379,7 @@ describe("Standardised invoice getter 0", () => {
         total: "mocked total",
         unit_price: "mocked unit price",
         vendor_name: "Billy Mitchell LLC",
+        vendor_id: "vendor_billy",
       },
     ]);
     expect(mockedGetInvoiceReceiptId).toHaveBeenCalledTimes(1);
@@ -483,6 +484,7 @@ describe("Standardised invoice getter 0", () => {
         total: "mocked total",
         unit_price: "mocked unit price",
         vendor_name: "Billy Mitchell LLC",
+        vendor_id: "vendor_billy",
       },
     ]);
     expect(mockedGetInvoiceReceiptId).toHaveBeenCalledTimes(1);
@@ -591,6 +593,7 @@ describe("Standardised invoice getter 0", () => {
         total: "mocked total",
         unit_price: "mocked unit price",
         vendor_name: "Billy Mitchell LLC",
+        vendor_id: "vendor_billy",
       },
     ]);
     expect(mockedGetInvoiceReceiptId).toHaveBeenCalledTimes(1);
@@ -666,6 +669,7 @@ describe("Standardised invoice getter 0", () => {
         total: "mocked total",
         unit_price: mockedUnitPrice,
         vendor_name: "Billy Mitchell LLC",
+        vendor_id: "vendor_billy",
       },
     ]);
     expect(mockedGetInvoiceReceiptId).toHaveBeenCalledTimes(1);

--- a/src/handlers/store-standardised-invoices/get-standardised-invoice/get-standardised-invoice-0.ts
+++ b/src/handlers/store-standardised-invoices/get-standardised-invoice/get-standardised-invoice-0.ts
@@ -54,6 +54,7 @@ export const getStandardisedInvoice0: StandardisationModule = (
 
   const summary = {
     invoice_receipt_id: getInvoiceReceiptId(summaryFields),
+    vendor_id: vendorServiceConfigRows[0].vendor_id,
     vendor_name: vendorServiceConfigRows[0].vendor_name,
     total: getTotal(summaryFields),
     invoice_receipt_date: getInvoiceReceiptDate(summaryFields),

--- a/src/handlers/store-standardised-invoices/get-standardised-invoice/get-standardised-invoice-default.test.ts
+++ b/src/handlers/store-standardised-invoices/get-standardised-invoice/get-standardised-invoice-default.test.ts
@@ -369,6 +369,7 @@ describe("Standardised invoice default getter", () => {
         total: "mocked total",
         unit_price: "mocked unit price",
         vendor_name: "Billy Mitchell LLC",
+        vendor_id: "vendor_billy",
       },
     ]);
     expect(mockedGetInvoiceReceiptId).toHaveBeenCalledTimes(1);

--- a/src/handlers/store-standardised-invoices/get-standardised-invoice/get-standardised-invoice-default.ts
+++ b/src/handlers/store-standardised-invoices/get-standardised-invoice/get-standardised-invoice-default.ts
@@ -29,6 +29,7 @@ export const getStandardisedInvoiceDefault: StandardisationModule = (
 
   const summary = {
     invoice_receipt_id: getInvoiceReceiptId(summaryFields),
+    vendor_id: vendorServiceConfigRows[0].vendor_id,
     vendor_name: vendorServiceConfigRows[0].vendor_name,
     total: getTotal(summaryFields),
     invoice_receipt_date: getInvoiceReceiptDate(summaryFields),

--- a/src/handlers/store-standardised-invoices/get-standardised-invoice/get-standardised-invoice.test.ts
+++ b/src/handlers/store-standardised-invoices/get-standardised-invoice/get-standardised-invoice.test.ts
@@ -23,7 +23,6 @@ const mockedGetStandardisedInvoiceDefault =
 describe("Standardised invoice getter", () => {
   let mockedStandardisedInvoice0: any;
   let mockedStandardisedInvoiceDefault: any;
-  let mockedVendorName: string;
   let givenVendorId: string;
   let givenConfigBucket: string;
   let givenTextractPages: Textract.ExpenseDocument[];
@@ -31,12 +30,14 @@ describe("Standardised invoice getter", () => {
   beforeEach(() => {
     jest.resetAllMocks();
 
+    givenVendorId = "given vendor ID";
+    givenConfigBucket = "given config bucket";
+    givenTextractPages = "given Textract pages" as any;
+
     mockedGetVendorInvoiceStandardisationModuleId.mockReturnValue(0);
 
     mockedGetVendorServiceConfigRows.mockResolvedValue([
-      {
-        vendor_name: mockedVendorName,
-      },
+      { vendor_id: givenVendorId },
     ]);
 
     mockedStandardisedInvoice0 = "mocked standardised invoice 0";
@@ -46,10 +47,6 @@ describe("Standardised invoice getter", () => {
     mockedGetStandardisedInvoiceDefault.mockResolvedValue(
       mockedStandardisedInvoiceDefault
     );
-
-    givenVendorId = "given vendor ID";
-    givenConfigBucket = "given config bucket";
-    givenTextractPages = "given Textract pages" as any;
   });
 
   test("Standardised invoice getter with standardisation config fetch error", async () => {
@@ -124,7 +121,7 @@ describe("Standardised invoice getter", () => {
     expect(mockedGetStandardisedInvoiceDefault).toHaveBeenCalledTimes(1);
     expect(mockedGetStandardisedInvoiceDefault).toHaveBeenCalledWith(
       givenTextractPages,
-      [{ vendor_name: undefined }]
+      [{ vendor_id: givenVendorId }]
     );
   });
 
@@ -142,7 +139,7 @@ describe("Standardised invoice getter", () => {
     expect(mockedGetStandardisedInvoiceDefault).toHaveBeenCalledTimes(1);
     expect(mockedGetStandardisedInvoiceDefault).toHaveBeenCalledWith(
       givenTextractPages,
-      [{ vendor_name: undefined }]
+      [{ vendor_id: givenVendorId }]
     );
   });
 
@@ -159,7 +156,7 @@ describe("Standardised invoice getter", () => {
     expect(mockedGetStandardisedInvoice0).toHaveBeenCalledTimes(1);
     expect(mockedGetStandardisedInvoice0).toHaveBeenCalledWith(
       givenTextractPages,
-      [{ vendor_name: undefined }]
+      [{ vendor_id: givenVendorId }]
     );
     expect(mockedGetStandardisedInvoiceDefault).not.toHaveBeenCalled();
   });

--- a/src/handlers/store-standardised-invoices/get-standardised-invoice/get-standardised-invoice.ts
+++ b/src/handlers/store-standardised-invoices/get-standardised-invoice/get-standardised-invoice.ts
@@ -9,6 +9,7 @@ import { getStandardisedInvoiceDefault } from "./get-standardised-invoice-defaul
 
 export interface StandardisedLineItem {
   invoice_receipt_id: string;
+  vendor_id?: string;
   vendor_name?: string;
   total: number;
   invoice_receipt_date: string;


### PR DESCRIPTION
This replaces the use of `vendor_name` as a unique identifier with `vendor_id` in various places