### PR TITLE
BTM-434 added expiration to buckets

### DIFF
--- a/cloudformation/calculation-s3.yaml
+++ b/cloudformation/calculation-s3.yaml
@@ -22,3 +22,7 @@ Resources:
       LoggingConfiguration:
         DestinationBucketName: !Ref GlobalLogBucket
         LogFilePrefix: storage-bucket/log
+      LifecycleConfiguration:
+        Rules:
+          - ExpirationInDays: 1825  # Five years
+            Status: Enabled

--- a/cloudformation/global.yaml
+++ b/cloudformation/global.yaml
@@ -91,6 +91,10 @@ Resources:
           - ServerSideEncryptionByDefault:
               SSEAlgorithm: aws:kms
               KMSMasterKeyID: !GetAtt KmsKey.Arn
+      LifecycleConfiguration:
+        Rules:
+          - ExpirationInDays: 1825  # Five years
+            Status: Enabled
 
   GlobalAccessLogsBucketPolicy:
     Type: AWS::S3::BucketPolicy

--- a/cloudformation/raw-invoice-pdf-store.yaml
+++ b/cloudformation/raw-invoice-pdf-store.yaml
@@ -30,3 +30,7 @@ Resources:
                   - Name: suffix
                     Value: '.pdf'
             Queue: !GetAtt ExtractQueue.Arn
+      LifecycleConfiguration:
+        Rules:
+          - ExpirationInDays: 1825  # Five years
+            Status: Enabled

--- a/cloudformation/raw-invoice-textract-data-store.yaml
+++ b/cloudformation/raw-invoice-textract-data-store.yaml
@@ -67,6 +67,10 @@ Resources:
                   - Name: suffix
                     Value: '.json'
             Queue: !GetAtt StandardisedInvoiceStorageQueue.Arn
+      LifecycleConfiguration:
+        Rules:
+          - ExpirationInDays: 1825  # Five years
+            Status: Enabled
 
   RawInvoiceTextractDataQueue:
     Type: AWS::SQS::Queue

--- a/cloudformation/transaction-csv-to-json-event.yaml
+++ b/cloudformation/transaction-csv-to-json-event.yaml
@@ -31,6 +31,10 @@ Resources:
                   - Name: suffix
                     Value: '.csv'
             Function: !GetAtt TransactionCsvToJsonEventFunction.Arn
+      LifecycleConfiguration:
+        Rules:
+          - ExpirationInDays: 1825  # Five years
+            Status: Enabled
 
   TransactionCsvToJsonEventFunction:
     # checkov:skip=CKV_AWS_116: DLQ not needed for lambda driven by SQS


### PR DESCRIPTION
For our Risks and Mitigations compliance, we’ve been asked to ensure data deletion after five years.  This can most easily be accomplished via setting a lifecycle expiration time on the relevant buckets themselves.