### PR TITLE
Add source maps

### DIFF
--- a/template-source.yaml
+++ b/template-source.yaml
@@ -88,6 +88,9 @@ Globals:
     Runtime: nodejs16.x
     Timeout: 30
     CodeUri: dist/
+    Environment:
+      Variables:
+        NODE_OPTIONS: --enable-source-maps
 
 Resources: !YAMLInclude ./cloudformation/global.yaml,
   ./cloudformation/test-only.yaml,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,6 +4,7 @@ import { fileURLToPath } from "url";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default {
+  devtool: "source-map",
   entry: {
     clean: "./src/handlers/clean/handler.ts",
     customAthenaViewResource:


### PR DESCRIPTION
This adds config for make AWS error logs show line numbers of source files instead of minified deployed code files