### PR TITLE
Untangle business logic

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -6,6 +6,7 @@ ignorePatterns:
 rules:
   '@typescript-eslint/strict-boolean-expressions': off
   '@typescript-eslint/restrict-template-expressions': off
+  '@typescript-eslint/naming-convention': off
 overrides:
   - files: '*.ts'
     parserOptions:

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "di-billing-transaction-monitoring",
       "version": "0.0.1",
       "devDependencies": {
+        "@aws-lambda-powertools/logger": "^1.6.0",
         "@aws-sdk/client-athena": "^3.188.0",
         "@aws-sdk/client-cloudformation": "^3.188.0",
         "@aws-sdk/client-cloudwatch-logs": "^3.188.0",
@@ -149,6 +150,22 @@
         "@aws-sdk/types": "^3.110.0",
         "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-lambda-powertools/commons": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/commons/-/commons-1.6.0.tgz",
+      "integrity": "sha512-83YWf63FZN872Bodk+tJHdSZ2o8y5zsAcpQZgBTqL8TEFNBef/zkDuIuvDIUBmif9q+ZaYVAEtileWjjDTvgGA==",
+      "dev": true
+    },
+    "node_modules/@aws-lambda-powertools/logger": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/logger/-/logger-1.6.0.tgz",
+      "integrity": "sha512-RIx8nHDH8exxPfMhkTnxWZMNOEOgf1CjkzbisLvX89/8Z0tMyruDFHdnolZXQ6Z1AyUE5FVaqN5FWlkmyqxS4A==",
+      "dev": true,
+      "dependencies": {
+        "@aws-lambda-powertools/commons": "^1.6.0",
+        "lodash.merge": "^4.6.2"
       }
     },
     "node_modules/@aws-sdk/abort-controller": {
@@ -15129,6 +15146,22 @@
         "@aws-sdk/types": "^3.110.0",
         "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
+      }
+    },
+    "@aws-lambda-powertools/commons": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/commons/-/commons-1.6.0.tgz",
+      "integrity": "sha512-83YWf63FZN872Bodk+tJHdSZ2o8y5zsAcpQZgBTqL8TEFNBef/zkDuIuvDIUBmif9q+ZaYVAEtileWjjDTvgGA==",
+      "dev": true
+    },
+    "@aws-lambda-powertools/logger": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/logger/-/logger-1.6.0.tgz",
+      "integrity": "sha512-RIx8nHDH8exxPfMhkTnxWZMNOEOgf1CjkzbisLvX89/8Z0tMyruDFHdnolZXQ6Z1AyUE5FVaqN5FWlkmyqxS4A==",
+      "dev": true,
+      "requires": {
+        "@aws-lambda-powertools/commons": "^1.6.0",
+        "lodash.merge": "^4.6.2"
       }
     },
     "@aws-sdk/abort-controller": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.1",
   "type": "module",
   "devDependencies": {
+    "@aws-lambda-powertools/logger": "^1.6.0",
     "@aws-sdk/client-athena": "^3.188.0",
     "@aws-sdk/client-cloudformation": "^3.188.0",
     "@aws-sdk/client-cloudwatch-logs": "^3.188.0",

--- a/src/handler-context/Config.ts
+++ b/src/handler-context/Config.ts
@@ -1,0 +1,137 @@
+import csvToJson from "csvtojson";
+
+export enum ConfigFileNames {
+  rates = "rates",
+  services = "services",
+  renamingMap = "renamingMap",
+  inferences = "inferences",
+  transformations = "transformations",
+  vat = "vat",
+  standardisation = "standardisation",
+  e2eTest = "e2eTest",
+}
+
+export type ConfigFiles = Record<ConfigFileNames, unknown>;
+
+enum FileTypes {
+  csv,
+  json,
+}
+
+const fileMap: Record<ConfigFileNames, { path: string; type: FileTypes }> = {
+  [ConfigFileNames.rates]: {
+    path: "rate_tables/rates.csv",
+    type: FileTypes.csv,
+  },
+  [ConfigFileNames.services]: {
+    path: "vendor_services/vendor-services.csv",
+    type: FileTypes.csv,
+  },
+  [ConfigFileNames.renamingMap]: {
+    path: "csv_transactions/header-row-renaming-map.json",
+    type: FileTypes.json,
+  },
+  [ConfigFileNames.inferences]: {
+    path: "csv_transactions/event-inferences.json",
+    type: FileTypes.json,
+  },
+  [ConfigFileNames.transformations]: {
+    path: "csv_transactions/event-transformation.json",
+    type: FileTypes.json,
+  },
+  [ConfigFileNames.vat]: { path: "uk-vat.json", type: FileTypes.json },
+  [ConfigFileNames.standardisation]: {
+    path: "vendor-invoice-standardisation.json",
+    type: FileTypes.json,
+  },
+  [ConfigFileNames.e2eTest]: { path: "e2e-test.json", type: FileTypes.json },
+};
+
+type Json = string | number | boolean | null | Json[] | { [key: string]: Json };
+
+interface ConfigClient {
+  getConfigFile: (path: string) => Promise<string>;
+}
+
+const parseCsvFile = async (rawFile: string): Promise<Json> => {
+  return await csvToJson().fromString(rawFile);
+};
+const parseJsonFile = (rawFile: string): Json => {
+  return JSON.parse(rawFile);
+};
+
+const parseConfigFile = async (
+  rawFile: string,
+  type: FileTypes
+): Promise<Json> => {
+  switch (type) {
+    case FileTypes.json:
+      return parseJsonFile(rawFile);
+    case FileTypes.csv:
+      return await parseCsvFile(rawFile);
+  }
+};
+
+export class Config<TFileName extends ConfigFileNames> {
+  private readonly _client: ConfigClient;
+  private readonly _files: ConfigFileNames[];
+  private _cache!: Omit<ConfigFiles, keyof Omit<ConfigFiles, TFileName>>;
+  private _promises!: Array<
+    Promise<{
+      parsedFile: Json;
+      fileName: ConfigFileNames;
+    }>
+  >;
+
+  constructor(client: ConfigClient, files: TFileName[]) {
+    this._client = client;
+    this._files = files;
+    this._populatePromises();
+    void this._populateCache();
+  }
+
+  private readonly _populatePromises = (): void => {
+    if (process.env.CONFIG_BUCKET === undefined)
+      throw new Error("No CONFIG_BUCKET defined in this environment");
+
+    this._promises = this._files.map(async (fileName) => {
+      const { path, type } = fileMap[fileName];
+      const promise = (async (): Promise<{
+        parsedFile: Json;
+        fileName: ConfigFileNames;
+      }> => {
+        const rawFile = await this._client.getConfigFile(path);
+        const parsedFile = await parseConfigFile(rawFile, type);
+        return { parsedFile, fileName };
+      })();
+      return await promise;
+    });
+  };
+
+  private readonly _populateCache = async (): Promise<void> => {
+    const resolutions = await Promise.allSettled(this._promises);
+    // @ts-expect-error
+    this._cache = resolutions.reduce<
+      Omit<ConfigFiles, keyof Omit<ConfigFiles, TFileName>>
+    >((_config, resolution) => {
+      if (resolution.status === "rejected") throw new Error(resolution.reason);
+      const { parsedFile, fileName } = resolution.value;
+      return {
+        ..._config,
+        [fileName]: parsedFile,
+      };
+      // @ts-expect-error
+    }, {});
+  };
+
+  public readonly getCache = (): Omit<
+    ConfigFiles,
+    keyof Omit<ConfigFiles, TFileName>
+  > => this._cache;
+}
+
+// the config utils we have are actually single use thingies so honestly I'm
+// tempted to say that reshaping a specific config file to meet a given handler's
+// needs is actually business logic. I'm not gunna worry about these for now, I'll
+// just get this config cacher up, move the fetchEventNames logic into filterBusinessLogic
+// and see how it looks.

--- a/src/handler-context/S3ConfigClient.ts
+++ b/src/handler-context/S3ConfigClient.ts
@@ -1,0 +1,28 @@
+import { GetObjectCommand, S3Client } from "@aws-sdk/client-s3";
+
+const getClient = (): S3Client =>
+  new S3Client({
+    region: "eu-west-2",
+    endpoint: process.env.LOCAL_ENDPOINT,
+  });
+
+export class S3ConfigFileClient {
+  private readonly _client: S3Client;
+
+  constructor() {
+    this._client = getClient();
+  }
+
+  public readonly getConfigFile = async (path: string): Promise<string> => {
+    const response = await this._client.send(
+      new GetObjectCommand({
+        Bucket: process.env.CONFIG_BUCKET,
+        Key: path,
+      })
+    );
+    if (response.Body === undefined) {
+      throw new Error(`Config file could not be found at ${path}`);
+    }
+    return await response.Body.transformToString();
+  };
+}

--- a/src/handler-context/index.ts
+++ b/src/handler-context/index.ts
@@ -1,0 +1,267 @@
+import { SQSEvent } from "aws-lambda";
+import { Logger } from "@aws-lambda-powertools/logger";
+import { Response } from "../shared/types";
+import { Config, ConfigFileNames } from "./Config";
+import { S3ConfigFileClient } from "./S3ConfigClient";
+
+export type OutputFunction = (
+  destination: string,
+  message: string
+) => Promise<void>;
+
+export type Outputs = Array<{
+  destination: string;
+  store: OutputFunction;
+}>;
+
+export type UserDefinedOutputFunction<TEnvVars extends string> = (
+  destination: TEnvVars,
+  message: string
+) => Promise<void>;
+
+export type UserDefinedOutputs<TEnvVars extends string> = Array<{
+  destination: TEnvVars;
+  store: UserDefinedOutputFunction<TEnvVars>;
+}>;
+
+export type BusinessLogicOutput = Array<{ _id: string }>;
+
+export type BusinessLogic<
+  TMessage,
+  TEnvVars extends string,
+  TConfigFileNames extends ConfigFileNames
+> = (
+  ctx: HandlerCtx<TMessage, TEnvVars, TConfigFileNames>
+) => Promise<BusinessLogicOutput>;
+
+export interface HandlerCtx<
+  TMessage,
+  TEnvVars extends string,
+  TConfigFileNames extends ConfigFileNames
+> {
+  env: Record<TEnvVars, string>;
+  messages: Array<TMessage & { _id: string }>;
+  logger: Logger;
+  outputs: Outputs;
+  config: Config<TConfigFileNames>["_cache"];
+}
+
+export type Handler<
+  TMessage,
+  TEnvVars extends string,
+  TConfigFileNames extends ConfigFileNames
+> = (
+  ctx: HandlerCtx<TMessage, TEnvVars, TConfigFileNames>
+) => Promise<Response>;
+
+interface CtxBuilderOptions<TMessage, TEnvVars extends string> {
+  envVars: TEnvVars[];
+  messageTypeGuard: (maybeMessage: unknown) => maybeMessage is TMessage;
+  outputs: UserDefinedOutputs<TEnvVars>;
+  configFiles: ConfigFileNames[];
+}
+
+export const addEnvToCtx = <
+  TMessage,
+  TEnvVars extends string,
+  TConfigFileNames extends ConfigFileNames
+>(
+  envVarsKeys: TEnvVars[],
+  ctx: HandlerCtx<TMessage, TEnvVars, TConfigFileNames>
+): HandlerCtx<TMessage, TEnvVars, TConfigFileNames> => {
+  const { isEnvValid, missingVars, env } = envVarsKeys.reduce<{
+    isEnvValid: boolean;
+    missingVars: string[];
+    env: HandlerCtx<TMessage, TEnvVars, TConfigFileNames>["env"];
+  }>(
+    (acc, envVarKey) => {
+      const envVar = process.env[envVarKey];
+      if (envVar === undefined || !envVarKey?.length) {
+        acc.isEnvValid = false;
+        acc.missingVars = [...acc.missingVars, envVarKey];
+      } else {
+        acc.env = {
+          ...acc.env,
+          [envVarKey]: envVar,
+        };
+      }
+      return acc;
+    },
+    {
+      isEnvValid: true,
+      missingVars: [],
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+      env: {} as HandlerCtx<TMessage, TEnvVars, TConfigFileNames>["env"],
+    }
+  );
+  if (!isEnvValid) {
+    ctx.logger.error(`Environment is not valid, missing ${missingVars.join()}`);
+    throw new Error(`Environment is not valid`);
+  }
+
+  return { ...ctx, env };
+};
+
+// N.B. this is an adaptor from SQSEvents to domain messages
+export const addMessagesToCtx = <
+  TMessage,
+  TEnvVars extends string,
+  TConfigFileNames extends ConfigFileNames
+>(
+  { Records }: SQSEvent,
+  messageTypeGuard: (maybeMessage: any) => maybeMessage is TMessage,
+  ctx: HandlerCtx<TMessage, TEnvVars, TConfigFileNames>
+): HandlerCtx<TMessage, TEnvVars, TConfigFileNames> => {
+  const messages = Records.map<
+    HandlerCtx<TMessage, TEnvVars, TConfigFileNames>["messages"][0]
+  >(({ messageId: _id, body: rawBody }) => {
+    let body;
+    try {
+      body = JSON.parse(rawBody);
+    } catch (error) {
+      ctx.logger.error(`Received a message whose body was not valid JSON`);
+      throw new Error(`Could not process message ${_id}`);
+    }
+    const messageIsExpectedType = messageTypeGuard(body);
+    if (!messageIsExpectedType) {
+      ctx.logger.error(
+        `Received a message which did not conform to the expected type`
+      );
+      throw new Error(`Could not process message ${_id}`);
+    }
+    // we attach the _id to the message so that we can handle batch item failures
+    return { ...body, _id };
+  });
+  return { ...ctx, messages };
+};
+
+export const addLoggerToCtx = <
+  TMessage,
+  TEnvVars extends string,
+  TConfigFileNames extends ConfigFileNames
+>(
+  ctx: HandlerCtx<TMessage, TEnvVars, TConfigFileNames>
+): HandlerCtx<TMessage, TEnvVars, TConfigFileNames> => {
+  return { ...ctx, logger: new Logger() };
+};
+
+export const addOutputsToCtx = <
+  TMessage,
+  TEnvVars extends string,
+  TConfigFileNames extends ConfigFileNames
+>(
+  outputs: UserDefinedOutputs<TEnvVars>,
+  ctx: HandlerCtx<TMessage, TEnvVars, TConfigFileNames>
+): HandlerCtx<TMessage, TEnvVars, TConfigFileNames> => {
+  return {
+    ...ctx,
+    outputs: outputs.map(({ destination, store }) => ({
+      destination: ctx.env[destination],
+      store: store as OutputFunction,
+    })),
+  };
+};
+
+export const outputMessages = async <
+  TMessage,
+  TEnvVars extends string,
+  TConfigFileNames extends ConfigFileNames
+>(
+  results: BusinessLogicOutput,
+  { outputs }: HandlerCtx<TMessage, TEnvVars, TConfigFileNames>
+): Promise<Response> => {
+  const promises = results
+    .map(({ _id, ...body }) =>
+      outputs.map<Promise<string>>(
+        async ({ destination, store }) =>
+          await new Promise((resolve, reject) => {
+            store(destination, JSON.stringify(body)).then(
+              () => resolve(_id),
+              () => reject(_id)
+            );
+          })
+      )
+    )
+    .flat();
+
+  return await Promise.allSettled(promises).then((resolutions) =>
+    resolutions.reduce<Response>(
+      (response, outputPromise) => {
+        if (outputPromise.status === "fulfilled") return response;
+        return {
+          ...response,
+          batchItemFailures: [
+            ...response.batchItemFailures,
+            outputPromise.reason,
+          ],
+        };
+      },
+      { batchItemFailures: [] }
+    )
+  );
+};
+
+export const addConfigToCtx = <
+  TMessage,
+  TEnvVars extends string,
+  TConfigFileNames extends ConfigFileNames
+>(
+  files: TConfigFileNames[],
+  ctx: HandlerCtx<TMessage, TEnvVars, TConfigFileNames>
+): HandlerCtx<TMessage, TEnvVars, TConfigFileNames> => {
+  const config = new Config(new S3ConfigFileClient(), files).getCache();
+  return { ...ctx, config };
+};
+
+export const getBlankCtx = <
+  TMessage,
+  TEnvVars extends string,
+  TConfigFileNames extends ConfigFileNames
+>(): HandlerCtx<TMessage, TEnvVars, TConfigFileNames> =>
+  ({} as unknown as HandlerCtx<TMessage, TEnvVars, TConfigFileNames>);
+
+export const buildHandler =
+  <
+    TMessage,
+    TEnvVars extends string,
+    TConfigFileNames extends ConfigFileNames
+  >({
+    envVars,
+    messageTypeGuard,
+    outputs,
+    configFiles,
+  }: CtxBuilderOptions<TMessage, TEnvVars>) =>
+  (businessLogic: BusinessLogic<TMessage, TEnvVars, TConfigFileNames>) =>
+  (event: SQSEvent) => {
+    // for the love of god find a nicer way to do this chain
+    const ctx = addConfigToCtx(
+      configFiles,
+      addOutputsToCtx(
+        outputs,
+        addMessagesToCtx(
+          event,
+          messageTypeGuard,
+          addEnvToCtx(envVars, addLoggerToCtx(getBlankCtx()))
+        )
+      )
+    );
+    return async () => {
+      const results = await businessLogic(ctx);
+      return await outputMessages(results, ctx);
+    };
+  };
+
+// Spin up some classes that model the config repo
+// so we can have config in the context. You should
+// be able to specify which bits on config a
+// given business blob depends on to negate over-fetching
+
+// That'll solve some of the fetching but what about the
+// bits where we need to go get something from a bucket
+// when the message says that something's been put there?
+
+// I think that'll be an extension of addMessagesToCtx.
+// at the minute that's specific to SQSEvents but to
+// work with the transaction csv to json events lambda
+// it'll need to toggle to a different modality to handle
+// S3Events

--- a/src/shared/utils/config-utils/fetch-vendor-service-config.ts
+++ b/src/shared/utils/config-utils/fetch-vendor-service-config.ts
@@ -35,7 +35,7 @@ export const fetchVendorServiceConfig = async (
   return vendorServiceConfig;
 };
 
-const isVendorServiceConfigRow = (x: any): x is VendorServiceConfigRow =>
+export const isVendorServiceConfigRow = (x: any): x is VendorServiceConfigRow =>
   typeof x === "object" &&
   typeof x.vendor_name === "string" &&
   typeof x.vendor_id === "string" &&


### PR DESCRIPTION
The goal is to distill the common elements of our lambdas and use them to build up a context which can be passed to business logic. 

Ideally procedures like asserting the presence of env vars or fetching required files from config will become declarative, meaning we can think more about what a lambda does and less about how it does it. 
