### PR TITLE
BTM-451: fix deployment

### DIFF
--- a/template-source.yaml
+++ b/template-source.yaml
@@ -91,8 +91,6 @@ Globals:
     Environment:
       Variables:
         NODE_OPTIONS: --enable-source-maps
-    Layers:
-      - arn:aws:lambda:eu-west-2:094274105915:layer:AWSLambdaPowertoolsTypeScript:6
 
 Resources: !YAMLInclude ./cloudformation/global.yaml,
   ./cloudformation/test-only.yaml,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,7 +21,7 @@ export default {
     transactionCsvToJsonEvent:
       "./src/handlers/transaction-csv-to-json-event/handler.ts",
   },
-  externals: ["@aws-lambda-powertools/logger", "aws-sdk"],
+  externals: "aws-sdk",
   mode: process.env.NODE_ENV === "dev" ? "development" : "production",
   module: {
     rules: [{ test: /\.ts$/, use: "ts-loader", exclude: /node_modules/ }],


### PR DESCRIPTION
This hopefully fixes deployment, which was failing due to AWS Lambda layers being disallowed by the GDS deployment stack. This just bundles the logger package with the Lambda function's JavaScript file instead of using a layer