### PR TITLE
BTM-284 Amend colour for negative discrepancies in the dashboard

### DIFF
--- a/grafana-json/billing-reconciliation-dashboard.preprod.json
+++ b/grafana-json/billing-reconciliation-dashboard.preprod.json
@@ -29,7 +29,7 @@
   "panels": [
     {
       "gridPos": {
-        "h": 4,
+        "h": 5,
         "w": 11,
         "x": 0,
         "y": 0
@@ -44,14 +44,14 @@
     },
     {
       "gridPos": {
-        "h": 4,
+        "h": 5,
         "w": 5,
         "x": 11,
         "y": 0
       },
       "id": 4,
       "options": {
-        "content": "<table style=\"border-collapse: collapse; border: none;\">\n<tr style=\"border: none;\"><td style=\"border: none; text-align: right\"><span style=\"color: red; border: none;\">Red</span></td><td style=\"border: none;\">Above 1%</td></tr>\n<tr style=\"border: none;\"><td style=\"border: none; text-align: right\"><span style=\"color: #59A94F; border: none;\">Green</span></td><td style=\"border: none;\">Less than or equal to 1%</td></tr>\n<tr style=\"border: none;\"><td style=\"border: none; text-align: right\"><span style=\"color: #676b71; border: none;\">Grey</span></td><td style=\"border: none;\">One or more data points is missing</td></tr>\n</table>",
+        "content": "<table style=\"border-collapse: collapse; border: none;\">\n<tr style=\"border: none;\"><td style=\"border: none; text-align: right\"><span style=\"color: red; border: none;\">Red</span></td><td style=\"border: none;\">Discrepancy is more than 1%</td></tr>\n<tr style=\"border: none;\"><td style=\"border: none; text-align: right\"><span style=\"color: #59A94F; border: none;\">Green</span></td><td style=\"border: none;\">Discrepancy is between -1% and 1%</td></tr>\n<tr style=\"border: none;\"><td style=\"border: none; text-align: right\"><span style=\"color: #648fff; border: none;\">Blue</span></td><td style=\"border: none;\">Discrepancy is less than -1%</td></tr>\n<tr style=\"border: none;\"><td style=\"border: none; text-align: right\"><span style=\"color: #676b71; border: none;\">Grey</span></td><td style=\"border: none;\">One or more data points is missing</td></tr>\n</table>",
         "mode": "markdown"
       },
       "pluginVersion": "8.4.7",
@@ -101,7 +101,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
+                "color": "blue",
                 "value": null
               },
               {
@@ -122,7 +122,7 @@
         "h": 8,
         "w": 16,
         "x": 0,
-        "y": 4
+        "y": 5
       },
       "id": 2,
       "links": [],
@@ -173,7 +173,7 @@
         "h": 4,
         "w": 16,
         "x": 0,
-        "y": 12
+        "y": 13
       },
       "id": 8,
       "options": {
@@ -255,7 +255,7 @@
         "h": 5,
         "w": 16,
         "x": 0,
-        "y": 16
+        "y": 17
       },
       "id": 10,
       "options": {


### PR DESCRIPTION
- Key added for a new entry for Blue “Discrepancy is less than -1%”.
- When there is a discrepancy between the invoiced and expected amounts that is less than -1%, this is displayed in Blue 

![image](https://user-images.githubusercontent.com/116570124/228600984-3dd54ccc-cfa8-4c23-a86b-83f2281f9f78.png)
