### PR TITLE
BTM-473 Fix for issue where retries happened even on success

### DIFF
--- a/integration_tests/tests/billing-and-transaction-view-tests.ts
+++ b/integration_tests/tests/billing-and-transaction-view-tests.ts
@@ -67,7 +67,7 @@ describe("\nUpload pdf invoice to raw invoice bucket and verify BillingAndTransa
             s3Object.Key?.includes(getYearMonth(data.eventTime))
           ).length === 1,
         {
-          timeout: 80000,
+          timeout: 120000,
           interval: 10000,
           nonCompleteErrorMessage:
             "Invoice data never appeared in standardised folder",

--- a/integration_tests/tests/s3-invoice-end-to-end-tests.ts
+++ b/integration_tests/tests/s3-invoice-end-to-end-tests.ts
@@ -35,6 +35,7 @@ describe("\n Happy path - Upload valid mock invoice pdf and verify data is seen 
       description: "address check",
     });
     const invoice = randomInvoice({
+      date: new Date("2023-03-31"),
       lineItems: [...passportCheckItems, ...addressCheckItems],
     });
     const expectedSubtotals = [

--- a/integration_tests/tests/s3-invoice-end-to-end-tests.ts
+++ b/integration_tests/tests/s3-invoice-end-to-end-tests.ts
@@ -71,7 +71,7 @@ describe("\n Happy path - Upload valid mock invoice pdf and verify data is seen 
           )
         ).length === 3,
       {
-        timeout: 80000,
+        timeout: 120000,
         interval: 10000,
         nonCompleteErrorMessage:
           "PDF Invoice data never appeared in standardised folder",

--- a/src/handlers/int-test-support/helpers/call-wrappers.test.ts
+++ b/src/handlers/int-test-support/helpers/call-wrappers.test.ts
@@ -84,11 +84,10 @@ describe("callWithRetry", () => {
     beforeEach(() => {
       attempt = 0;
     });
-    const alwaysFailsWithIncrementingErrorMessage = async (): Promise<string> =>
-      await new Promise((resolve, reject) => {
-        attempt++;
-        reject(new Error(`failure on attempt ${attempt}`));
-      });
+    const alwaysFailsWithIncrementingErrorMessage = async (): Promise<void> => {
+      attempt++;
+      throw new Error(`failure on attempt ${attempt}`);
+    };
 
     describe("when using the default retry option of always retrying", () => {
       it("fails to retrieve a value", async () => {

--- a/src/handlers/int-test-support/helpers/call-wrappers.test.ts
+++ b/src/handlers/int-test-support/helpers/call-wrappers.test.ts
@@ -34,10 +34,10 @@ describe("callWithTimeout", () => {
 describe("callWithRetry", () => {
   describe("given a function that succeeds the first time", () => {
     it("successfully retrieves the value", async () => {
-      const result = await callWithRetry(3)(
-        async () => await new Promise((resolve) => resolve("a"))
-      )();
+      const asyncFunc = jest.fn(async (): Promise<string> => "a");
+      const result = await callWithRetry(3)(asyncFunc)();
       expect(result).toBe("a");
+      expect(asyncFunc).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -80,22 +80,32 @@ describe("callWithRetry", () => {
   });
 
   describe("given a function that fails consistently", () => {
-    describe("when using the default retry option of always retrying", () => {
-      let attempt: number;
-      beforeEach(() => {
-        attempt = 0;
+    let attempt: number;
+    beforeEach(() => {
+      attempt = 0;
+    });
+    const alwaysFailsWithIncrementingErrorMessage = async (): Promise<string> =>
+      await new Promise((resolve, reject) => {
+        attempt++;
+        reject(new Error(`failure on attempt ${attempt}`));
       });
-      const alwaysFailsWithIncrementingErrorMessage =
-        async (): Promise<string> =>
-          await new Promise((resolve, reject) => {
-            attempt++;
-            reject(new Error(`failure on attempt ${attempt}`));
-          });
 
-      it("fails to retrieve a value and throws the error from the last attempt", async () => {
+    describe("when using the default retry option of always retrying", () => {
+      it("fails to retrieve a value", async () => {
         await expect(
           callWithRetry(3)(alwaysFailsWithIncrementingErrorMessage)()
-        ).rejects.toThrowError(new Error("failure on attempt 3"));
+        ).rejects.toThrowError(new Error("Ran out of retries"));
+      });
+    });
+
+    describe("when using a retry option that doesn't match the thrown error", () => {
+      it("fails with the first error thrown", async () => {
+        await expect(
+          callWithRetry(
+            3,
+            (error: Error): boolean => error.message === "some other error"
+          )(alwaysFailsWithIncrementingErrorMessage)()
+        ).rejects.toThrowError(new Error("failure on attempt 1"));
       });
     });
   });

--- a/src/handlers/int-test-support/helpers/call-wrappers.ts
+++ b/src/handlers/int-test-support/helpers/call-wrappers.ts
@@ -53,8 +53,8 @@ export const callWithRetry =
       try {
         return await asyncFunc.apply(null, underlyingArgs);
       } catch (error) {
-        if (retryOnErrorMatching(error as Error)) {
-          logger.warn(`Retrying on error: ${(error as Error)?.message}`);
+        if (error instanceof Error && retryOnErrorMatching(error)) {
+          logger.warn(`Retrying on error: ${error.message}`);
           return await callWithRetry(
             retries - 1,
             retryOnErrorMatching


### PR DESCRIPTION
Due to a logic error that wasn't tested for, retrying was occurring even when the function call was successful.  This PR contains a fix and expanded tests.