### PR TITLE
BTM-533: New table for holding extracts of the combined view

### DIFF
--- a/cloudformation/calculation-athena.yaml
+++ b/cloudformation/calculation-athena.yaml
@@ -8,6 +8,52 @@ Resources:
       DatabaseInput:
         Name: !Sub ${AWS::StackName}-calculations
 
+  MonthlyExtractTable:
+    Type: AWS::Glue::Table
+    Properties:
+      CatalogId: !Ref AWS::AccountId
+      DatabaseName: !Ref CalculationsDB
+      TableInput:
+        Name: btm_monthly_extract
+        TableType: EXTERNAL_TABLE
+        Parameters:
+          has_encrypted_data: true
+          storage.location.template: !Sub s3://${StorageBucket}/btm_extract_data/full-extract.json
+        StorageDescriptor:
+          Columns:
+            - Name: vendor_id
+              Type: string
+            - Name: vendor_name
+              Type: string
+            - Name: service_name
+              Type: string
+            - Name: year
+              Type: string
+            - Name: month
+              Type: string
+            - Name: billing_price_formatted
+              Type: string
+            - Name: transaction_price_formatted
+              Type: string
+            - Name: price_difference
+              Type: string
+            - Name: billing_amount_with_tax
+              Type: string
+            - Name: price_difference_percentage
+              Type: double
+          Compressed: true
+          InputFormat: org.apache.hadoop.mapred.TextInputFormat
+          Location: !Sub s3://${StorageBucket}/btm_extract_data/
+          StoredAsSubDirectories: false
+          OutputFormat: org.apache.hadoop.hive.ql.io.IgnoreKeyTextOutputFormat
+          SerdeInfo:
+            Parameters:
+              ignore.malformed.json: true
+              serialization.format: 1
+              field.delim: ','
+              timestamp.formats: yyyy-MM-dd
+            SerializationLibrary: org.openx.data.jsonserde.JsonSerDe
+
   TransactionTable:
     Type: AWS::Glue::Table
     Properties:
@@ -54,11 +100,9 @@ Resources:
           OutputFormat: org.apache.hadoop.hive.ql.io.IgnoreKeyTextOutputFormat
           SerdeInfo:
             Parameters:
-              {
-                ignore.malformed.json: true,
-                serialization.format: 1,
-                field.delim: '',
-              }
+              ignore.malformed.json: true
+              serialization.format: 1
+              field.delim: ''
             SerializationLibrary: org.openx.data.jsonserde.JsonSerDe
 
   RateTableTable:

--- a/grafana-json/billing-reconciliation-dashboard.preprod.json
+++ b/grafana-json/billing-reconciliation-dashboard.preprod.json
@@ -155,9 +155,9 @@
             "uid": "--BnYST4z"
           },
           "format": 1,
-          "rawSQL": "SELECT \n  vendor_name AS \"Vendor\",\n  service_name AS \"Service\",\n  price_difference_percentage\nFROM \"btm_billing_and_transactions_curated\" \nWHERE\n  vendor_name IN (${vendorNames:singlequote}) AND\n   year = SUBSTRING(${yearMonth:singlequote},1,4) AND\n   month = SUBSTRING(${yearMonth:singlequote},6,2)\nORDER BY vendor_name, year, month",
+          "rawSQL": "SELECT \n  vendor_name AS \"Vendor\",\n  service_name AS \"Service\",\n  price_difference_percentage\nFROM \"btm_monthly_extract\" \nWHERE\n  vendor_name IN (${vendorNames:singlequote}) AND\n   year = SUBSTRING(${yearMonth:singlequote},1,4) AND\n   month = SUBSTRING(${yearMonth:singlequote},6,2)\nORDER BY vendor_name, year, month",
           "refId": "A",
-          "table": "btm_billing_and_transactions_curated"
+          "table": "btm_monthly_extract"
         }
       ],
       "transformations": [
@@ -279,9 +279,9 @@
             "uid": "--BnYST4z"
           },
           "format": 1,
-          "rawSQL": "SELECT \n  vendor_name AS \"Vendor\",\n  service_name AS \"Service\",\n  billing_price_formatted AS \"Invoiced Amount\",\n  transaction_price_formatted AS \"Expected Amount\",\n  price_difference_percentage AS \"% Discrepancy\",\n  price_difference AS \"Discrepancy in £\",\n  billing_amount_with_tax AS \"Total Invoice + VAT\"\nFROM \"btm_billing_and_transactions_curated\" \nWHERE\n  vendor_name IN (${vendorNames:singlequote}) AND\n   year = SUBSTRING(${yearMonth:singlequote},1,4) AND\n   month = SUBSTRING(${yearMonth:singlequote},6,2)\nORDER BY vendor_name, year, month",
+          "rawSQL": "SELECT \n  vendor_name AS \"Vendor\",\n  service_name AS \"Service\",\n  billing_price_formatted AS \"Invoiced Amount\",\n  transaction_price_formatted AS \"Expected Amount\",\n  price_difference AS \"Discrepancy in £\",\n  price_difference_percentage AS \"% Discrepancy\",\n  billing_amount_with_tax AS \"Total Invoice + VAT\"\nFROM \"btm_monthly_extract\" \nWHERE\n  vendor_name IN (${vendorNames:singlequote}) AND\n   year = SUBSTRING(${yearMonth:singlequote},1,4) AND\n   month = SUBSTRING(${yearMonth:singlequote},6,2)\nORDER BY vendor_name, year, month",
           "refId": "A",
-          "table": "btm_billing_and_transactions_curated"
+          "table": "btm_monthly_extract"
         }
       ],
       "type": "table"
@@ -318,8 +318,8 @@
             "region": "__default"
           },
           "format": 1,
-          "rawSQL": "SELECT vendor_name FROM \"btm_billing_and_transactions_curated\" ORDER BY vendor_name ASC ",
-          "table": "btm_billing_and_transactions_curated"
+          "rawSQL": "SELECT vendor_name FROM \"btm_monthly_extract\" ORDER BY vendor_name ASC ",
+          "table": "btm_monthly_extract"
         },
         "refresh": 1,
         "regex": "",
@@ -351,8 +351,8 @@
             "region": "__default"
           },
           "format": 1,
-          "rawSQL": "SELECT DISTINCT CONCAT(year, '/', month) as yearMonth FROM \"btm_billing_and_transactions_curated\" ORDER BY yearMonth ASC",
-          "table": "btm_billing_and_transactions_curated"
+          "rawSQL": "SELECT DISTINCT CONCAT(year, '/', month) as yearMonth FROM \"btm_monthly_extract\" ORDER BY yearMonth ASC",
+          "table": "btm_monthly_extract"
         },
         "refresh": 1,
         "regex": "",


### PR DESCRIPTION
Creates a new table containing extracted data as a temporary fix for speed problem.

Initially this table will be populated by hand.  Grafana should just be able to reference this new table as its data source, as it contains the exact same fields as the old view.

A later fix will see this table being populated automatically.