### PR TITLE
BTM 534: fix email bucket permission

### DIFF
--- a/cloudformation/email.yaml
+++ b/cloudformation/email.yaml
@@ -36,4 +36,7 @@ Resources:
               StringEquals:
                 aws:SourceAccount: !Ref AWS::AccountId
                 aws:SourceArn:
-                  - !Sub arn:aws:ses:eu-west-1:${AWS::AccountId}:receipt-rule-set/di-btm-tooling-email-${Environment}-receipt-rule-set:receipt-rule/di-btm-tooling-email-${Environment}-vendor1-receipt-rule
+                  - !If
+                    - IsDev
+                    - !Sub arn:aws:ses:eu-west-1:${AWS::AccountId}:receipt-rule-set/di-btm-tooling-email-dev-receipt-rule-set:receipt-rule/di-btm-tooling-email-dev-vendor1-receipt-rule
+                    - !Sub arn:aws:ses:eu-west-1:${AWS::AccountId}:receipt-rule-set/di-btm-tooling-email-${Environment}-receipt-rule-set:receipt-rule/di-btm-tooling-email-${Environment}-vendor1-receipt-rule


### PR DESCRIPTION
This fixes a problem with the permission policy for the email bucket in the dev deployment environment. It was caused by not accounting for the Environment parameter being `build` instead of `dev` in the dev environment when building the ARN for the resource to which to grant permission