### PR TITLE
BTM-430 CSV test fix

### DIFF
--- a/integration_tests/tests/s3-invoice-end-to-end-tests.ts
+++ b/integration_tests/tests/s3-invoice-end-to-end-tests.ts
@@ -20,7 +20,7 @@ import {
   prettyVendorNameMap,
 } from "../../src/handlers/int-test-support/helpers/payloadHelper";
 
-describe("\n Happy path - Upload valid mock invoice pdf and verify data is seen in the billing view\n", () => {
+describe("\n Happy path - Upload valid mock invoice and verify data is seen in the billing view\n", () => {
   let filename: string;
 
   test("upload valid pdf file in raw-invoice bucket and see that we can see the data in the view", async () => {

--- a/integration_tests/tests/s3-invoice-end-to-end-tests.ts
+++ b/integration_tests/tests/s3-invoice-end-to-end-tests.ts
@@ -138,13 +138,10 @@ describe("\n Happy path - Upload valid mock invoice pdf and verify data is seen 
       },
     });
 
-    const s3Object = await createInvoiceInS3({
+    await createInvoiceInS3({
       invoiceData: invoice,
       filename: `${filename}.csv`,
     });
-
-    const checkRawPdfFileExists = await checkIfS3ObjectExists(s3Object);
-    expect(checkRawPdfFileExists).toBeTruthy();
 
     // Check they were standardised
     await Promise.all([

--- a/src/handlers/int-test-support/helpers/mock-data/invoice/helpers.ts
+++ b/src/handlers/int-test-support/helpers/mock-data/invoice/helpers.ts
@@ -118,7 +118,7 @@ export const checkStandardised = async (
     {
       interval: 10000,
       notCompleteErrorMessage: `${itemDescription} not found`,
-      timeout: 120000,
+      timeout: 130000,
     }
   );
 

--- a/src/handlers/int-test-support/helpers/mock-data/invoice/helpers.ts
+++ b/src/handlers/int-test-support/helpers/mock-data/invoice/helpers.ts
@@ -118,7 +118,7 @@ export const checkStandardised = async (
     {
       interval: 10000,
       notCompleteErrorMessage: `${itemDescription} not found`,
-      timeout: 130000,
+      timeout: 145000,
     }
   );
 


### PR DESCRIPTION
removed the assertion to check file exists in raw bucket, thought this assertion is not required as the next step checkStandardised will fail if the file is not the bucket.
Increased time out in checkStandardised function