### PR TITLE
Btm 576 Serialisable types for runViaLambda int test helpers

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -7,6 +7,7 @@ rules:
   '@typescript-eslint/strict-boolean-expressions': off
   '@typescript-eslint/restrict-template-expressions': off
   '@typescript-eslint/naming-convention': off
+  '@typescript-eslint/consistent-type-definitions': off
 overrides:
   - files: '*.ts'
     parserOptions:

--- a/integration_tests/tests/s3-invoice-raw-store-tests.ts
+++ b/integration_tests/tests/s3-invoice-raw-store-tests.ts
@@ -17,13 +17,13 @@ describe("\n Unhappy path - Upload invalid pdf to the raw invoice bucket test\n"
   const uniqueString = Math.random().toString(36).substring(2, 7);
   const rawInvoice: S3Object = {
     bucket: `${prefix}-raw-invoice`,
-    key: `${givenVendorIdFolder}/raw-Invoice-${uniqueString}-validFile.pdf`,
+    key: `${givenVendorIdFolder}/raw-Invoice-${uniqueString}-invalidFile.pdf`,
   };
 
   test("should move the original raw invoice to failed folder in s3 raw-invoice bucket upon uploading the invalid pdf file ", async () => {
     const file = "../payloads/invalidFileToTestTextractFailure.pdf";
     const filename = path.join(__dirname, file);
-    const fileData = fs.readFileSync(filename);
+    const fileData = fs.readFileSync(filename).toString();
 
     await putS3Object({ data: fileData, target: rawInvoice });
 

--- a/src/handlers/int-test-support/handler.test.ts
+++ b/src/handlers/int-test-support/handler.test.ts
@@ -64,4 +64,16 @@ describe("Handler test for integration test support function", () => {
       "Function 'someUnknownCommand' is not implemented."
     );
   });
+  test("Input event with non-serializable parameters results in error", async () => {
+    inputEvent = {
+      environment: "test-env",
+      config: "test-config",
+      command: IntTestHelpers.getS3Object,
+      parameters: { some: new Date() },
+    };
+
+    await expect(handler(inputEvent, givenContext)).rejects.toThrowError(
+      "Invalid parameter: Non Serializable value"
+    );
+  });
 });

--- a/src/handlers/int-test-support/handler.test.ts
+++ b/src/handlers/int-test-support/handler.test.ts
@@ -64,16 +64,4 @@ describe("Handler test for integration test support function", () => {
       "Function 'someUnknownCommand' is not implemented."
     );
   });
-  test("Input event with non-serializable parameters results in error", async () => {
-    inputEvent = {
-      environment: "test-env",
-      config: "test-config",
-      command: IntTestHelpers.getS3Object,
-      parameters: { some: new Date() },
-    };
-
-    await expect(handler(inputEvent, givenContext)).rejects.toThrowError(
-      "Invalid parameter: Non Serializable value"
-    );
-  });
 });

--- a/src/handlers/int-test-support/handler.test.ts
+++ b/src/handlers/int-test-support/handler.test.ts
@@ -11,7 +11,7 @@ const mockedListS3Objects = listS3Objects as jest.MockedFunction<
 >;
 
 let givenContext: Context;
-let inputEvent: TestSupportEvent;
+let inputEvent: TestSupportEvent<IntTestHelpers>;
 
 beforeEach(() => {
   jest.resetAllMocks();

--- a/src/handlers/int-test-support/handler.ts
+++ b/src/handlers/int-test-support/handler.ts
@@ -112,9 +112,9 @@ export const handler = async <T extends IntTestHelpers>(
   process.env.CONFIG_NAME = event.config;
 
   console.log(
-    `Executing command "${event.command}" with parameters "${Object.keys(
-      event.parameters !== null
-    )}" in environment "${event.environment}" with config "${event.config}"`
+    `Executing command "${event.command}" with parameters "${
+      event.parameters !== null ? `${Object.keys(event.parameters)}` : null
+    }" in environment "${event.environment}" with config "${event.config}"`
   );
 
   const retVal = await callFunction(event.command, event.parameters);

--- a/src/handlers/int-test-support/handler.ts
+++ b/src/handlers/int-test-support/handler.ts
@@ -20,11 +20,19 @@ import {
 import { createInvoiceInS3 } from "./helpers/mock-data/invoice/helpers";
 import { invokeLambda } from "./helpers/lambdaHelper";
 
-export interface TestSupportEvent {
+export type SerializableData =
+  | string
+  | number
+  | boolean
+  | null
+  | SerializableData[]
+  | {};
+
+export interface TestSupportEvent<T extends IntTestHelpers> {
   environment: string;
   config: string;
-  command: IntTestHelpers;
-  parameters: any;
+  command: T;
+  parameters: SerializableData;
 }
 
 export interface TestSupportReturn {
@@ -96,8 +104,8 @@ const callFunction = async (
   throw new Error(`Function '${name}' is not implemented.`);
 };
 
-export const handler = async (
-  event: TestSupportEvent,
+export const handler = async <T extends IntTestHelpers>(
+  event: TestSupportEvent<T>,
   _context: Context
 ): Promise<TestSupportReturn> => {
   process.env.ENV_NAME = event.environment;
@@ -105,7 +113,7 @@ export const handler = async (
 
   console.log(
     `Executing command "${event.command}" with parameters "${Object.keys(
-      event.parameters
+      event.parameters !== null
     )}" in environment "${event.environment}" with config "${event.config}"`
   );
 

--- a/src/handlers/int-test-support/handler.ts
+++ b/src/handlers/int-test-support/handler.ts
@@ -26,8 +26,7 @@ export type SerializableData =
   | boolean
   | null
   | SerializableData[]
-  | { [key: string]: SerializableData }
-  | ArrayBuffer;
+  | { [key: string]: SerializableData };
 
 export interface TestSupportEvent<T extends IntTestHelpers> {
   environment: string;

--- a/src/handlers/int-test-support/handler.ts
+++ b/src/handlers/int-test-support/handler.ts
@@ -26,7 +26,8 @@ export type SerializableData =
   | boolean
   | null
   | SerializableData[]
-  | { [key: string]: SerializableData };
+  | { [key: string]: SerializableData }
+  | ArrayBuffer;
 
 export interface TestSupportEvent<T extends IntTestHelpers> {
   environment: string;

--- a/src/handlers/int-test-support/handler.ts
+++ b/src/handlers/int-test-support/handler.ts
@@ -95,6 +95,9 @@ const callFunction = async (
   name: IntTestHelpers,
   parameters: any
 ): Promise<any> => {
+  if (!isSerializable(parameters)) {
+    throw new Error("Invalid parameter: Non Serializable value");
+  }
   if (functionMap[name] !== undefined) {
     const func: Function = functionMap[name];
     const ret = await func(parameters);
@@ -120,4 +123,22 @@ export const handler = async <T extends IntTestHelpers>(
   const retVal = await callFunction(event.command, event.parameters);
 
   return { success: true, successObject: retVal };
+};
+
+const isSerializable = (data: unknown): SerializableData => {
+  if (
+    typeof data === "string" ||
+    typeof data === "boolean" ||
+    typeof data === "number" ||
+    data === null ||
+    Array.isArray(data)
+  ) {
+    if (Array.isArray(data)) {
+      return data.every(isSerializable);
+    }
+    return true;
+  } else if (typeof data === "object") {
+    return Object.keys(data).length === 0;
+  }
+  return false;
 };

--- a/src/handlers/int-test-support/handler.ts
+++ b/src/handlers/int-test-support/handler.ts
@@ -26,7 +26,7 @@ export type SerializableData =
   | boolean
   | null
   | SerializableData[]
-  | {};
+  | { [key: string]: SerializableData };
 
 export interface TestSupportEvent<T extends IntTestHelpers> {
   environment: string;
@@ -95,9 +95,6 @@ const callFunction = async (
   name: IntTestHelpers,
   parameters: any
 ): Promise<any> => {
-  if (!isSerializable(parameters)) {
-    throw new Error("Invalid parameter: Non Serializable value");
-  }
   if (functionMap[name] !== undefined) {
     const func: Function = functionMap[name];
     const ret = await func(parameters);
@@ -123,22 +120,4 @@ export const handler = async <T extends IntTestHelpers>(
   const retVal = await callFunction(event.command, event.parameters);
 
   return { success: true, successObject: retVal };
-};
-
-const isSerializable = (data: unknown): SerializableData => {
-  if (
-    typeof data === "string" ||
-    typeof data === "boolean" ||
-    typeof data === "number" ||
-    data === null ||
-    Array.isArray(data)
-  ) {
-    if (Array.isArray(data)) {
-      return data.every(isSerializable);
-    }
-    return true;
-  } else if (typeof data === "object") {
-    return Object.keys(data).length === 0;
-  }
-  return false;
 };

--- a/src/handlers/int-test-support/helpers/athenaHelper.ts
+++ b/src/handlers/int-test-support/helpers/athenaHelper.ts
@@ -10,10 +10,10 @@ import { athenaClient } from "../clients";
 import { sendLambdaCommand } from "./lambdaHelper";
 import { IntTestHelpers } from "../handler";
 
-interface DatabaseQuery {
+type DatabaseQuery = {
   databaseName: string;
   queryString: string;
-}
+};
 
 interface QueryStatus {
   state?: string;

--- a/src/handlers/int-test-support/helpers/cloudWatchHelper.ts
+++ b/src/handlers/int-test-support/helpers/cloudWatchHelper.ts
@@ -9,16 +9,16 @@ import { cloudWatchLogsClient } from "../clients";
 import { sendLambdaCommand } from "./lambdaHelper";
 import { IntTestHelpers } from "../handler";
 
-interface LogCheckParameters {
+type LogCheckParameters = {
   logName: string;
   expectedString: string;
   testStartTime: number;
-}
-interface LogEvent {
+};
+type LogEvent = {
   eventId?: string;
   message?: string;
   logStreamName?: string;
-}
+};
 
 export async function getRecentCloudwatchLogs(params: {
   logName: string;

--- a/src/handlers/int-test-support/helpers/lambdaHelper.ts
+++ b/src/handlers/int-test-support/helpers/lambdaHelper.ts
@@ -1,12 +1,12 @@
 import { InvokeCommand, InvokeCommandInput } from "@aws-sdk/client-lambda";
 import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
 import { lambdaClient } from "../clients";
-import { HelperDict, IntTestHelpers } from "../handler";
+import { HelperDict, IntTestHelpers, SerializableData } from "../handler";
 import { configName, envName, resourcePrefix, runViaLambda } from "./envHelper";
 
 export const sendLambdaCommand = async <THelper extends IntTestHelpers>(
   command: THelper,
-  parameters: Parameters<HelperDict[THelper]>[0]
+  parameters: Parameters<HelperDict[THelper]>[0] & SerializableData
 ): Promise<string> => {
   const payload = JSON.stringify({
     environment: envName(),
@@ -30,16 +30,16 @@ export const sendLambdaCommand = async <THelper extends IntTestHelpers>(
   }
 };
 
-export interface InvokeLambdaParams {
+type InvokeLambdaParams = {
   functionName: string;
   payload: string;
   forceWithoutLambda?: boolean;
-}
+};
 
-interface InvokeLambdaResponse {
+type InvokeLambdaResponse = {
   statusCode: number | undefined;
   payload?: Uint8Array;
-}
+};
 
 export const invokeLambda = async (
   params: InvokeLambdaParams

--- a/src/handlers/int-test-support/helpers/mock-data/csv/index.ts
+++ b/src/handlers/int-test-support/helpers/mock-data/csv/index.ts
@@ -3,7 +3,7 @@ import { objectsToCSV } from "./objectsToCsv";
 import { testCases } from "./transformCSV-to-event-test-data";
 
 export const mockCsvData = (): {
-  csv: Buffer;
+  csv: string;
   happyPathCount: number;
   testCases: TestCases;
 } => {
@@ -25,5 +25,5 @@ export const mockCsvData = (): {
   const happyPathCount = testCases.filter(
     ({ expectedPath }) => expectedPath === "happy"
   ).length;
-  return { csv: Buffer.from(csvString), happyPathCount, testCases };
+  return { csv: csvString, happyPathCount, testCases };
 };

--- a/src/handlers/int-test-support/helpers/mock-data/invoice/helpers.ts
+++ b/src/handlers/int-test-support/helpers/mock-data/invoice/helpers.ts
@@ -10,10 +10,10 @@ import { TestData } from "../../testDataHelper";
 import { E2ETestParserServiceConfig } from "../../../config-utils/get-e2e-test-config";
 import { poll } from "../../commonHelpers";
 
-interface InvoiceDataAndFileName {
+type InvoiceDataAndFileName = {
   invoiceData: InvoiceData;
   filename: string;
-}
+};
 
 export const createInvoiceInS3 = async (
   params: InvoiceDataAndFileName

--- a/src/handlers/int-test-support/helpers/mock-data/invoice/invoice.ts
+++ b/src/handlers/int-test-support/helpers/mock-data/invoice/invoice.ts
@@ -3,7 +3,7 @@ import autoTable from "jspdf-autotable";
 import { InvoiceData } from "./types";
 
 export type WriteFunc<TWriteOutput> = (
-  file: ArrayBuffer,
+  file: string,
   folder: string,
   filename: string
 ) => Promise<TWriteOutput>;
@@ -120,7 +120,7 @@ export const makeMockInvoicePDF =
       ],
     });
     doc.text(`Invoice number: ${invoice.invoiceNumber}`, 2, 20);
-    return await writeOutput(doc.output("arraybuffer"), folder, filename);
+    return await writeOutput(doc.output(), folder, filename);
   };
 
 export const makeMockInvoiceCSV =
@@ -159,6 +159,5 @@ export const makeMockInvoiceCSV =
       ],
     ];
     const csvString = csvData.map((row) => row.join(",")).join("\n");
-    const csvDataArrayBuffer = Buffer.from(csvString);
-    return await writeOutput(csvDataArrayBuffer, folder, filename);
+    return await writeOutput(csvString, folder, filename);
   };

--- a/src/handlers/int-test-support/helpers/mock-data/invoice/types.ts
+++ b/src/handlers/int-test-support/helpers/mock-data/invoice/types.ts
@@ -1,28 +1,28 @@
-export interface LineItem {
+export type LineItem = {
   description: string;
   quantity: number;
   unitPrice: number;
   vat: number;
   subtotal: number;
-}
+};
 
-export interface Vendor {
+export type Vendor = {
   id: string;
   name: string;
   address: string[];
   vatNumber: string;
-}
+};
 
-export interface Customer {
+export type Customer = {
   name: string;
   address: string[];
-}
+};
 
-export interface InvoiceData {
+export type InvoiceData = {
   vendor: Vendor;
   customer: Customer;
   dateString: string;
   dueDateString: string;
   invoiceNumber: string;
   lineItems: LineItem[];
-}
+};

--- a/src/handlers/int-test-support/helpers/mock-data/invoice/writers.ts
+++ b/src/handlers/int-test-support/helpers/mock-data/invoice/writers.ts
@@ -5,7 +5,7 @@ import { putS3Object, S3Object } from "../../s3Helper";
 import { WriteFunc } from "./invoice";
 
 export const writeInvoiceToS3 = async (
-  file: ArrayBuffer,
+  file: string,
   directory: string,
   filename: string
 ): Promise<S3Object> => {
@@ -20,12 +20,12 @@ export const writeInvoiceToS3 = async (
 // This is just for testing the invoice creation during dev
 // eslint-disable-next-line @typescript-eslint/promise-function-async
 export const writeInvoiceToDisk: WriteFunc<void> = (
-  file: ArrayBuffer,
+  file: string,
   directory: string,
   filename: string
 ): Promise<void> =>
   new Promise((resolve, reject) => {
-    writeFile(join(directory, filename), new DataView(file), (err) => {
+    writeFile(join(directory, filename), file, (err) => {
       if (err !== null) return reject(err);
       resolve();
     });

--- a/src/handlers/int-test-support/helpers/s3Helper.ts
+++ b/src/handlers/int-test-support/helpers/s3Helper.ts
@@ -13,41 +13,41 @@ import { sendLambdaCommand } from "./lambdaHelper";
 import { IntTestHelpers } from "../handler";
 import { callWithRetryAndTimeout } from "./call-wrappers";
 
-export interface S3Object {
+export type S3Object = {
   bucket: string;
   key: string;
-}
+};
 
-interface BucketAndPrefix {
+type BucketAndPrefix = {
   bucketName: string;
   prefix?: string;
-}
+};
 
-interface DataAndTarget {
+type DataAndTarget = {
   data: ArrayBuffer;
   target: S3Object;
-}
+};
 
-interface DeleteS3ObjectsByPrefix {
+type DeleteS3ObjectsByPrefix = {
   bucket: string;
   prefixes: string[];
-}
+};
 
-interface DeleteS3Objects {
+type DeleteS3Objects = {
   bucket: string;
   keys: string[];
-}
+};
 
-interface DeletedObject {
+type DeletedObject = {
   key?: string;
   versionId?: string;
-}
+};
 
-interface S3ObjectContent {
+type S3ObjectContent = {
   key?: string;
   size?: number;
   lastModified?: Date;
-}
+};
 
 const listS3ObjectsBasic = async (
   params: BucketAndPrefix

--- a/src/handlers/int-test-support/helpers/s3Helper.ts
+++ b/src/handlers/int-test-support/helpers/s3Helper.ts
@@ -24,7 +24,7 @@ type BucketAndPrefix = {
 };
 
 type DataAndTarget = {
-  data: ArrayBuffer;
+  data: string;
   target: S3Object;
 };
 
@@ -121,7 +121,7 @@ const putS3ObjectBasic = async (
   const bucketParams = {
     Bucket: dataAndTarget.target.bucket,
     Key: dataAndTarget.target.key,
-    Body: Buffer.from(dataAndTarget.data),
+    Body: Buffer.from(dataAndTarget.data, "ascii"),
   };
   try {
     await s3Client.send(new PutObjectCommand(bucketParams));


### PR DESCRIPTION
1. Added serailizableData types to allow specific types 
2. Refactored 'TestSupportEvent interface. Replaced generic 'any' type for the parameters property with defined SerializableData type
3. TestSupportEvent interface uses generic type parameter 'T extends IntTestHelpers' to capture specific value of command property