### PR TITLE
BTM-584 Fix test failures

### DIFF
--- a/integration_tests/tests/billing-and-transaction-view-tests.ts
+++ b/integration_tests/tests/billing-and-transaction-view-tests.ts
@@ -68,7 +68,7 @@ export const assertQueryResultWithTestData = async (
   vendorId: string,
   serviceName: string
 ): Promise<void> => {
-  const tableName = TableNames.BILLING_TRANSACTION_CURATED;
+  const tableName = TableNames.BILLING_AND_TRANSACTION_CURATED;
   const response = await getFilteredQueryResponse<BillingTransactionCurated>(
     tableName,
     vendorId,

--- a/integration_tests/tests/e2e-tests.ts
+++ b/integration_tests/tests/e2e-tests.ts
@@ -79,7 +79,7 @@ export const assertQueryResultWithTestData = async (
   vendorId: string,
   serviceName: string
 ): Promise<void> => {
-  const tableName = TableNames.BILLING_TRANSACTION_CURATED;
+  const tableName = TableNames.BILLING_AND_TRANSACTION_CURATED;
   const response = await getFilteredQueryResponse<BillingTransactionCurated>(
     tableName,
     vendorId,

--- a/integration_tests/tests/s3-invoice-data-tests.ts
+++ b/integration_tests/tests/s3-invoice-data-tests.ts
@@ -1,25 +1,27 @@
-import { resourcePrefix } from "../../src/handlers/int-test-support/helpers/envHelper";
 import { listS3Objects } from "../../src/handlers/int-test-support/helpers/s3Helper";
-
-const prefix = resourcePrefix();
+import {
+  RAW_INVOICE_BUCKET,
+  RAW_INVOICE_TEXTRACT_BUCKET,
+  STORAGE_BUCKET,
+} from "../../src/handlers/int-test-support/test-constants";
 
 describe("\n Invoice data buckets exists in S3\n", () => {
   test("Raw invoice bucket should exists in S3", async () => {
     const response = await listS3Objects({
-      bucketName: `${prefix}-raw-invoice`,
+      bucketName: RAW_INVOICE_BUCKET,
     });
     expect(response).toBeTruthy();
   });
 
   test("Raw invoice textract data bucket should exists in S3", async () => {
     const response = await listS3Objects({
-      bucketName: `${prefix}-raw-invoice-textract-data`,
+      bucketName: RAW_INVOICE_TEXTRACT_BUCKET,
     });
     expect(response).toBeTruthy();
   });
 
   test("Storage bucket should exists in S3", async () => {
-    const response = await listS3Objects({ bucketName: `${prefix}-storage` });
+    const response = await listS3Objects({ bucketName: STORAGE_BUCKET });
     expect(response).toBeTruthy();
   });
 });

--- a/integration_tests/tests/s3-invoice-end-to-end-tests.ts
+++ b/integration_tests/tests/s3-invoice-end-to-end-tests.ts
@@ -3,7 +3,10 @@ import {
   deleteS3Objects,
   listS3Objects,
 } from "../../src/handlers/int-test-support/helpers/s3Helper";
-import { poll } from "../../src/handlers/int-test-support/helpers/commonHelpers";
+import {
+  poll,
+  TableNames,
+} from "../../src/handlers/int-test-support/helpers/commonHelpers";
 import {
   Invoice,
   randomInvoiceData,
@@ -77,7 +80,7 @@ describe("\n Happy path - Upload valid mock invoice and verify data is seen in t
       ),
     ]);
     // Check the view results match the invoice.
-    const queryString = `SELECT * FROM "btm_billing_curated" where vendor_id = 'vendor_testvendor3'`;
+    const queryString = `SELECT * FROM ${TableNames.BILLING_CURATED} where vendor_id = 'vendor_testvendor3'`;
     const queryObjects = await queryAthena<BillingCurated>(queryString);
     expect(queryObjects.length).toEqual(2);
     queryObjects.sort((q0, q1) => {
@@ -170,7 +173,9 @@ describe("\n Happy path - Upload valid mock invoice and verify data is seen in t
     ]);
 
     // Step 3: Check the view results match the original csv invoice.
-    const queryString = `SELECT * FROM "btm_billing_curated" where vendor_id = '${
+    const queryString = `SELECT * FROM ${
+      TableNames.BILLING_CURATED
+    } where vendor_id = '${
       invoice.vendor.id
     }' AND year='${invoice.date.getFullYear()}' AND month='${(
       invoice.date.getMonth() + 1

--- a/integration_tests/tests/s3-invoice-raw-store-tests.ts
+++ b/integration_tests/tests/s3-invoice-raw-store-tests.ts
@@ -1,6 +1,5 @@
 import path from "path";
 import fs from "fs";
-import { resourcePrefix } from "../../src/handlers/int-test-support/helpers/envHelper";
 import {
   checkIfS3ObjectExists,
   deleteS3Objects,
@@ -9,14 +8,13 @@ import {
   S3Object,
 } from "../../src/handlers/int-test-support/helpers/s3Helper";
 import { poll } from "../../src/handlers/int-test-support/helpers/commonHelpers";
-
-const prefix = resourcePrefix();
+import { RAW_INVOICE_BUCKET } from "../../src/handlers/int-test-support/test-constants";
 const givenVendorIdFolder = "vendor123";
 
 describe("\n Unhappy path - Upload invalid pdf to the raw invoice bucket test\n", () => {
   const uniqueString = Math.random().toString(36).substring(2, 7);
   const rawInvoice: S3Object = {
-    bucket: `${prefix}-raw-invoice`,
+    bucket: RAW_INVOICE_BUCKET,
     key: `${givenVendorIdFolder}/raw-Invoice-${uniqueString}-invalidFile.pdf`,
   };
 

--- a/integration_tests/tests/s3-invoice-standardised-line-item-tests.ts
+++ b/integration_tests/tests/s3-invoice-standardised-line-item-tests.ts
@@ -2,7 +2,6 @@ import {
   E2ETestParserServiceConfig,
   getE2ETestConfig,
 } from "../../src/handlers/int-test-support/config-utils/get-e2e-test-config";
-import { resourcePrefix } from "../../src/handlers/int-test-support/helpers/envHelper";
 import {
   randomInvoiceData,
   randomString,
@@ -12,30 +11,12 @@ import {
   createInvoiceInS3,
 } from "../../src/handlers/int-test-support/helpers/mock-data/invoice/helpers";
 import {
-  deleteS3Objects,
   listS3Objects,
   S3Object,
 } from "../../src/handlers/int-test-support/helpers/s3Helper";
 
 describe("New invoice with same month, vendor, service as old line item", () => {
-  // Data to clean up after test
-  let givenService1Invoice: S3Object | undefined;
-  let givenService1LineItem: S3Object | undefined;
-  let givenService2Invoice: S3Object | undefined;
-  let givenService2LineItem: S3Object | undefined;
-  let resultNewService1Invoice: S3Object | undefined;
-  let resultNewService1LineItem: S3Object | undefined;
-
-  // Reset data between tests
-  beforeEach(() => {
-    givenService1Invoice = undefined;
-    givenService1LineItem = undefined;
-    givenService2Invoice = undefined;
-    givenService2LineItem = undefined;
-    resultNewService1Invoice = undefined;
-    resultNewService1LineItem = undefined;
-  });
-
+  let givenService1LineItem: S3Object;
   test("should archive old line item", async () => {
     const givenDate = getRandomInvoiceDate();
 
@@ -47,13 +28,13 @@ describe("New invoice with same month, vendor, service as old line item", () => 
     } = await getE2ETestConfig();
 
     // Upload two invoices with different vendor services
-    [givenService1Invoice, givenService2Invoice] = await Promise.all([
+    await Promise.all([
       uploadInvoice(givenDate, givenVendorId, givenVendorService1),
       uploadInvoice(givenDate, givenVendorId, givenVendorService2),
     ]);
 
     // Check they were standardised
-    [givenService1LineItem, givenService2LineItem] = await Promise.all([
+    [givenService1LineItem] = await Promise.all([
       checkStandardised(
         givenDate,
         givenVendorId,
@@ -69,14 +50,10 @@ describe("New invoice with same month, vendor, service as old line item", () => 
     ]);
 
     // Upload new invoice for existing vendor service
-    resultNewService1Invoice = await uploadInvoice(
-      givenDate,
-      givenVendorId,
-      givenVendorService1
-    );
+    await uploadInvoice(givenDate, givenVendorId, givenVendorService1);
 
     // Check it was standardised
-    resultNewService1LineItem = await checkStandardised(
+    await checkStandardised(
       givenDate,
       givenVendorId,
       givenVendorService1,
@@ -102,87 +79,7 @@ describe("New invoice with same month, vendor, service as old line item", () => 
       { archived: false }
     );
   });
-
-  // Delete any uploaded test files
-  afterEach(async () => {
-    const possibleInvoices: Array<S3Object | undefined> = [
-      givenService1Invoice,
-      givenService2Invoice,
-      resultNewService1Invoice,
-    ];
-    const invoices = possibleInvoices.filter(Boolean) as S3Object[];
-    const invoicePromises = invoices.map(deleteInvoice);
-
-    const possibleLineItems: Array<S3Object | undefined> = [
-      givenService1LineItem,
-      givenService2LineItem,
-      resultNewService1LineItem,
-    ];
-    const lineItems = possibleLineItems.filter(Boolean) as S3Object[];
-    const lineItemPromises = lineItems.map(deleteLineItem);
-
-    await Promise.all([...invoicePromises, ...lineItemPromises]);
-  });
 });
-
-const deleteExisting = async (
-  bucket: string,
-  prefixes: string[]
-): Promise<void> => {
-  const keyListPromises = prefixes.map(
-    async (prefix) => await listS3Keys(bucket, prefix)
-  );
-
-  const keyArrays = await Promise.all(keyListPromises);
-
-  const keys = keyArrays.flat();
-
-  const deletionPromises = keys.map(
-    async (key) => await deleteS3Objects({ bucket, keys: [key] })
-  );
-
-  await Promise.all(deletionPromises);
-};
-
-const deleteInvoice = async (pdf: S3Object): Promise<void> => {
-  const [folderName, pdfFileName] = pdf.key.split("/");
-  const textractFileName = pdfFileName.replace(/\.pdf$/gi, ".json");
-
-  await Promise.all([
-    deletePdf(folderName, pdfFileName),
-    deleteTextractData(folderName, textractFileName),
-  ]);
-};
-
-const deleteLineItem = async ({ bucket, key }: S3Object): Promise<void> => {
-  const [_, fileName] = key.split("/");
-  const keys = [key, `btm_invoice_data_archived/${fileName}`];
-  await deleteExisting(bucket, keys);
-};
-
-const deletePdf = async (
-  folderName: string,
-  fileName: string
-): Promise<void> => {
-  const bucket = `${resourcePrefix()}-raw-invoice`;
-
-  const keys = [
-    `${folderName}/${fileName}`,
-    `successful/${fileName}`,
-    `failed/${fileName}`,
-  ];
-
-  await deleteExisting(bucket, keys);
-};
-
-const deleteTextractData = async (
-  folderName: string,
-  fileName: string
-): Promise<void> => {
-  const bucket = `${resourcePrefix()}-raw-invoice-textract-data`;
-  const key = `${folderName}/${fileName}`;
-  await deleteExisting(bucket, [key]);
-};
 
 const getRandomInteger = (minInteger: number, maxInteger: number): number =>
   minInteger + Math.floor(Math.random() * (maxInteger - minInteger + 1));

--- a/integration_tests/tests/s3-lambda-tests.ts
+++ b/integration_tests/tests/s3-lambda-tests.ts
@@ -1,10 +1,12 @@
 import { validEventPayload } from "../../src/handlers/int-test-support/helpers/payloadHelper";
-import { resourcePrefix } from "../../src/handlers/int-test-support/helpers/envHelper";
 import { getRecentCloudwatchLogs } from "../../src/handlers/int-test-support/helpers/cloudWatchHelper";
 import { poll } from "../../src/handlers/int-test-support/helpers/commonHelpers";
 import { generateEventViaFilterLambdaAndCheckEventInS3Bucket } from "../../src/handlers/int-test-support/helpers/testDataHelper";
-
-const logNamePrefix = resourcePrefix();
+import {
+  FILTER_FUNCTION,
+  CLEAN_FUNCTION,
+  STORE_FUNCTION,
+} from "../../src/handlers/int-test-support/test-constants";
 
 async function waitForSubstringInLogs(
   logName: string,
@@ -14,7 +16,7 @@ async function waitForSubstringInLogs(
   await poll(
     async () =>
       await getRecentCloudwatchLogs({
-        logName: logNamePrefix + logName,
+        logName,
       }),
 
     (results) =>
@@ -43,15 +45,15 @@ describe(
     });
 
     test("Filter function cloud watch logs should contain eventid", async () => {
-      await waitForSubstringInLogs("-filter-function", eventId);
+      await waitForSubstringInLogs(FILTER_FUNCTION, eventId);
     });
 
     test("Clean function cloud watch logs should contain eventid", async () => {
-      await waitForSubstringInLogs("-clean-function", eventId);
+      await waitForSubstringInLogs(CLEAN_FUNCTION, eventId);
     });
 
     test("Store Transactions function cloud watch logs should contain eventid", async () => {
-      await waitForSubstringInLogs("-storage-function", eventId);
+      await waitForSubstringInLogs(STORE_FUNCTION, eventId);
     });
   }
 );

--- a/integration_tests/tests/transactionCSV-to-s3-event-tests.ts
+++ b/integration_tests/tests/transactionCSV-to-s3-event-tests.ts
@@ -2,17 +2,17 @@ import {
   deleteS3Event,
   poll,
 } from "../../src/handlers/int-test-support/helpers/commonHelpers";
-import { resourcePrefix } from "../../src/handlers/int-test-support/helpers/envHelper";
 import { mockCsvData } from "../../src/handlers/int-test-support/helpers/mock-data/csv";
 import {
   getS3Object,
   listS3Objects,
   putS3Object,
 } from "../../src/handlers/int-test-support/helpers/s3Helper";
-
-const transactionsDirectory = "btm_event_data";
-const outputBucket = `${resourcePrefix()}-storage`;
-const inputBucket = `${resourcePrefix()}-transaction-csv`;
+import {
+  TRANSACTION_CSV_BUCKET,
+  STORAGE_BUCKET,
+  S3_TRANSACTION_FOLDER,
+} from "../../src/handlers/int-test-support/test-constants";
 
 const { csv, happyPathCount, testCases } = mockCsvData();
 
@@ -22,7 +22,7 @@ describe("Given a csv with event data is uploaded to the transaction csv bucket"
 
     await putS3Object({
       target: {
-        bucket: inputBucket,
+        bucket: TRANSACTION_CSV_BUCKET,
         key: `fakeBillingReport.csv`,
       },
       data: csv,
@@ -30,8 +30,8 @@ describe("Given a csv with event data is uploaded to the transaction csv bucket"
     await poll(
       async () =>
         await listS3Objects({
-          bucketName: outputBucket,
-          prefix: `${transactionsDirectory}/2023/01/01/`,
+          bucketName: STORAGE_BUCKET,
+          prefix: `${S3_TRANSACTION_FOLDER}/2023/01/01/`,
         }),
       (result) => {
         return result.length === happyPathCount;
@@ -46,8 +46,8 @@ describe("Given a csv with event data is uploaded to the transaction csv bucket"
   it("stores the events we care about in the storage bucket", async () => {
     for (const testCase of testCases) {
       const s3Object = await getS3Object({
-        bucket: outputBucket,
-        key: `${transactionsDirectory}/2023/01/01/${testCase.expectedEventId}.json`,
+        bucket: STORAGE_BUCKET,
+        key: `${S3_TRANSACTION_FOLDER}/2023/01/01/${testCase.expectedEventId}.json`,
       });
       switch (testCase.expectedPath) {
         case "happy": {

--- a/jest.e2e.config.ts
+++ b/jest.e2e.config.ts
@@ -8,7 +8,7 @@ const config: Config.InitialOptions = {
   testRunner: "jasmine2",
   globalSetup: "./src/handlers/int-test-support/helpers/testSetup.ts",
   verbose: true,
-  testTimeout: 300000,
+  testTimeout: 320000,
   reporters: [
     "default",
     [

--- a/jest.integration.config.ts
+++ b/jest.integration.config.ts
@@ -8,7 +8,7 @@ const config: Config.InitialOptions = {
   testRunner: "jasmine2",
   globalSetup: "./src/handlers/int-test-support/helpers/testSetup.ts",
   verbose: true,
-  testTimeout: 300000,
+  testTimeout: 320000,
   reporters: [
     "default",
     [

--- a/src/handlers/int-test-support/config-utils/get-e2e-test-config.ts
+++ b/src/handlers/int-test-support/config-utils/get-e2e-test-config.ts
@@ -1,5 +1,6 @@
 import { configStackName } from "../helpers/envHelper";
 import { getS3Object } from "../helpers/s3Helper";
+import { E2E_TEST_CONFIG_PATH } from "../test-constants";
 
 const configBucket = configStackName();
 
@@ -9,7 +10,7 @@ export const getE2ETestConfig = async (): Promise<E2ETestConfig> => {
   if (e2eTestConfigRowsPromise === undefined) {
     e2eTestConfigRowsPromise = getS3Object({
       bucket: configBucket,
-      key: "e2e-test.json",
+      key: E2E_TEST_CONFIG_PATH,
     });
   }
   return JSON.parse((await e2eTestConfigRowsPromise) ?? "");

--- a/src/handlers/int-test-support/config-utils/get-rate-config-rows.ts
+++ b/src/handlers/int-test-support/config-utils/get-rate-config-rows.ts
@@ -1,5 +1,6 @@
 import { getS3Object } from "../helpers/s3Helper";
 import csvtojson from "csvtojson";
+import { RATE_TABLE_CONFIG_PATH } from "../test-constants";
 
 export type RateConfigRows = RateConfigRow[];
 
@@ -11,7 +12,7 @@ export const getRatesFromConfig = async (
   if (ratesRowsPromise === undefined) {
     ratesRowsPromise = getS3Object({
       bucket: configBucket,
-      key: "rate_tables/rates.csv",
+      key: RATE_TABLE_CONFIG_PATH,
     });
   }
   const ratesConfigText = await ratesRowsPromise;

--- a/src/handlers/int-test-support/config-utils/get-vendor-service-config-rows.ts
+++ b/src/handlers/int-test-support/config-utils/get-vendor-service-config-rows.ts
@@ -1,5 +1,6 @@
 import { getS3Object } from "../helpers/s3Helper";
 import csvtojson from "csvtojson";
+import { VENDOR_SERVICE_CONFIG_PATH } from "../test-constants";
 
 export type VendorServiceRows = VendorServiceRow[];
 
@@ -20,7 +21,7 @@ export const getVendorServiceConfigRows = async (
   if (vendorServiceRowsPromise === undefined) {
     vendorServiceRowsPromise = getS3Object({
       bucket: configBucket,
-      key: "vendor_services/vendor-services.csv",
+      key: VENDOR_SERVICE_CONFIG_PATH,
     });
   }
 

--- a/src/handlers/int-test-support/helpers/athenaHelper.ts
+++ b/src/handlers/int-test-support/helpers/athenaHelper.ts
@@ -5,10 +5,11 @@ import {
   StartQueryExecutionCommand,
 } from "@aws-sdk/client-athena";
 import { poll } from "./commonHelpers";
-import { resourcePrefix, runViaLambda } from "./envHelper";
 import { athenaClient } from "../clients";
 import { sendLambdaCommand } from "./lambdaHelper";
 import { IntTestHelpers } from "../handler";
+import { ATHENA_WORKGROUP } from "../test-constants";
+import { runViaLambda } from "./envHelper";
 
 type DatabaseQuery = {
   databaseName: string;
@@ -33,11 +34,13 @@ export const startQueryExecutionCommand = async (
       Database: query.databaseName,
     },
     QueryString: query.queryString,
-    WorkGroup: `${resourcePrefix()}-athena-workgroup`,
+    WorkGroup: ATHENA_WORKGROUP,
   };
   const response = await athenaClient.send(
     new StartQueryExecutionCommand(params)
   );
+  console.log(params.QueryString);
+  console.log(response);
   const queryId = response.QueryExecutionId ?? "queryId not found";
   return queryId;
 };

--- a/src/handlers/int-test-support/helpers/athenaHelper.ts
+++ b/src/handlers/int-test-support/helpers/athenaHelper.ts
@@ -56,6 +56,8 @@ export const getQueryExecutionStatus = async (
   const response = await athenaClient.send(
     new GetQueryExecutionCommand(params)
   );
+
+  console.log(response.QueryExecution?.Status);
   return {
     state: response.QueryExecution?.Status?.State,
     stateChangeReason: response.QueryExecution?.Status?.StateChangeReason,

--- a/src/handlers/int-test-support/helpers/athenaHelper.ts
+++ b/src/handlers/int-test-support/helpers/athenaHelper.ts
@@ -39,8 +39,6 @@ export const startQueryExecutionCommand = async (
   const response = await athenaClient.send(
     new StartQueryExecutionCommand(params)
   );
-  console.log(params.QueryString);
-  console.log(response);
   const queryId = response.QueryExecutionId ?? "queryId not found";
   return queryId;
 };
@@ -59,8 +57,6 @@ export const getQueryExecutionStatus = async (
   const response = await athenaClient.send(
     new GetQueryExecutionCommand(params)
   );
-
-  console.log(response.QueryExecution?.Status);
   return {
     state: response.QueryExecution?.Status?.State,
     stateChangeReason: response.QueryExecution?.Status?.StateChangeReason,

--- a/src/handlers/int-test-support/helpers/commonHelpers.ts
+++ b/src/handlers/int-test-support/helpers/commonHelpers.ts
@@ -1,13 +1,12 @@
 import { deleteS3Objects, listS3Objects } from "./s3Helper";
-import { resourcePrefix } from "./envHelper";
 import { EventPayload, generateRandomId } from "./payloadHelper";
 import { generateEventViaFilterLambdaAndCheckEventInS3Bucket } from "./testDataHelper";
-
-const objectsPrefix = "btm_event_data";
+import { S3_TRANSACTION_FOLDER, STORAGE_BUCKET } from "../test-constants";
 
 export enum TableNames {
-  BILLING_TRANSACTION_CURATED = "btm_billing_and_transactions_curated",
+  BILLING_AND_TRANSACTION_CURATED = "btm_billing_and_transactions_curated",
   TRANSACTION_CURATED = "btm_transactions_curated",
+  BILLING_CURATED = "btm_billing_curated",
 }
 
 export const poll = async <Resolution>(
@@ -98,14 +97,14 @@ export const deleteS3Event = async (
   eventId: string,
   eventTime: string
 ): Promise<boolean> => {
-  const bucketName = `${resourcePrefix()}-storage`;
+  const bucketName = STORAGE_BUCKET;
   const date = new Date(eventTime);
   const year = date.getFullYear();
   const month = (date.getMonth() + 1).toString().padStart(2, "0");
   const day = date.getDate().toString().padStart(2, "0");
   await deleteS3Objects({
     bucket: bucketName,
-    keys: [`${objectsPrefix}/${year}/${month}/${day}/${eventId}.json`],
+    keys: [`${S3_TRANSACTION_FOLDER}/${year}/${month}/${day}/${eventId}.json`],
   });
   return true;
 };
@@ -123,8 +122,8 @@ export const checkS3BucketForEventId = async (
 ): Promise<boolean> => {
   const pollS3BucketForEventIdString = async (): Promise<boolean> => {
     const result = await listS3Objects({
-      bucketName: `${resourcePrefix()}-storage`,
-      prefix: "btm_event_data",
+      bucketName: STORAGE_BUCKET,
+      prefix: S3_TRANSACTION_FOLDER,
     });
     if (result !== undefined) {
       return result.some((obj) => obj.key?.includes(eventIdString));

--- a/src/handlers/int-test-support/helpers/lambdaHelper.ts
+++ b/src/handlers/int-test-support/helpers/lambdaHelper.ts
@@ -2,7 +2,8 @@ import { InvokeCommand, InvokeCommandInput } from "@aws-sdk/client-lambda";
 import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
 import { lambdaClient } from "../clients";
 import { HelperDict, IntTestHelpers, SerializableData } from "../handler";
-import { configName, envName, resourcePrefix, runViaLambda } from "./envHelper";
+import { INT_TEST_SUPPORT_FUNCTION } from "../test-constants";
+import { configName, envName, runViaLambda } from "./envHelper";
 
 export const sendLambdaCommand = async <THelper extends IntTestHelpers>(
   command: THelper,
@@ -17,7 +18,7 @@ export const sendLambdaCommand = async <THelper extends IntTestHelpers>(
 
   // logger.info(toUtf8(commandInput.Payload as Uint8Array));
   const result = await invokeLambda({
-    functionName: `${resourcePrefix()}-int-test-support-function`,
+    functionName: INT_TEST_SUPPORT_FUNCTION,
     payload,
     forceWithoutLambda: true,
   });

--- a/src/handlers/int-test-support/helpers/mock-data/invoice/helpers.ts
+++ b/src/handlers/int-test-support/helpers/mock-data/invoice/helpers.ts
@@ -1,7 +1,7 @@
 import { listS3Objects, S3Object } from "../../s3Helper";
 import { Invoice, makeMockInvoicePDF, makeMockInvoiceCSV } from "./invoice";
 import { writeInvoiceToS3 } from "./writers";
-import { resourcePrefix, runViaLambda } from "../../envHelper";
+import { runViaLambda } from "../../envHelper";
 import { sendLambdaCommand } from "../../lambdaHelper";
 import { InvoiceData } from "./types";
 import { IntTestHelpers } from "../../../handler";
@@ -9,6 +9,11 @@ import { randomLineItem, randomString, randomInvoiceData } from "./random";
 import { TestData } from "../../testDataHelper";
 import { E2ETestParserServiceConfig } from "../../../config-utils/get-e2e-test-config";
 import { poll } from "../../commonHelpers";
+import {
+  S3_INVOICE_ARCHIVED_FOLDER,
+  S3_INVOICE_FOLDER,
+  STORAGE_BUCKET,
+} from "../../../test-constants";
 
 type InvoiceDataAndFileName = {
   invoiceData: InvoiceData;
@@ -84,8 +89,8 @@ const getLineItemPrefix = (
   const filePrefix = `${year}-${monthText}-${vendorId}-${eventName}-`;
 
   return archived
-    ? `btm_invoice_data_archived/${filePrefix}`
-    : `btm_invoice_data/${year}/${monthText}/${filePrefix}`;
+    ? `${S3_INVOICE_ARCHIVED_FOLDER}/${filePrefix}`
+    : `${S3_INVOICE_FOLDER}/${year}/${monthText}/${filePrefix}`;
 };
 
 export const checkStandardised = async (
@@ -98,7 +103,7 @@ export const checkStandardised = async (
     keyToExclude = undefined,
   }: { archived?: boolean; keyToExclude?: string } = {}
 ): Promise<S3Object> => {
-  const bucket = `${resourcePrefix()}-storage`;
+  const bucket = STORAGE_BUCKET;
 
   const prefix = getLineItemPrefix(
     date,
@@ -115,7 +120,7 @@ export const checkStandardised = async (
     {
       interval: 20000,
       notCompleteErrorMessage: `${itemDescription} not found`,
-      timeout: 280000,
+      timeout: 300000,
     }
   );
 

--- a/src/handlers/int-test-support/helpers/mock-data/invoice/writers.ts
+++ b/src/handlers/int-test-support/helpers/mock-data/invoice/writers.ts
@@ -1,8 +1,8 @@
 import { writeFile } from "fs";
 import { join } from "path";
-import { resourcePrefix } from "../../envHelper";
 import { putS3Object, S3Object } from "../../s3Helper";
 import { WriteFunc } from "./invoice";
+import { RAW_INVOICE_BUCKET } from "../../../test-constants";
 
 export const writeInvoiceToS3 = async (
   file: string,
@@ -10,7 +10,7 @@ export const writeInvoiceToS3 = async (
   filename: string
 ): Promise<S3Object> => {
   const s3Object = {
-    bucket: `${resourcePrefix()}-raw-invoice`,
+    bucket: RAW_INVOICE_BUCKET,
     key: `${directory}/${filename}`,
   };
   await putS3Object({ data: file, target: s3Object });

--- a/src/handlers/int-test-support/helpers/queryHelper.ts
+++ b/src/handlers/int-test-support/helpers/queryHelper.ts
@@ -2,16 +2,13 @@ import {
   startQueryExecutionCommand,
   waitAndGetQueryResults,
 } from "./athenaHelper";
-import { resourcePrefix } from "./envHelper";
-
-const prefix = resourcePrefix();
-const databaseName = `${prefix}-calculations`;
+import { DATABASE_NAME } from "../test-constants";
 
 export const queryAthena = async <TResponse>(
   queryString: string
 ): Promise<TResponse[]> => {
   const queryId = await startQueryExecutionCommand({
-    databaseName,
+    databaseName: DATABASE_NAME,
     queryString,
   });
   return await waitAndGetQueryResults(queryId);

--- a/src/handlers/int-test-support/helpers/testDataHelper.ts
+++ b/src/handlers/int-test-support/helpers/testDataHelper.ts
@@ -1,10 +1,11 @@
-import { configStackName, resourcePrefix } from "./envHelper";
+import { configStackName } from "./envHelper";
 import { invokeLambda } from "./lambdaHelper";
 import { EventPayload, updateSQSEventPayloadBody } from "./payloadHelper";
 import { getRatesFromConfig } from "../config-utils/get-rate-config-rows";
 import { getVendorServiceConfigRows } from "../config-utils/get-vendor-service-config-rows";
 import { getE2ETestConfig } from "../config-utils/get-e2e-test-config";
 import { checkS3BucketForEventId } from "./commonHelpers";
+import { FILTER_FUNCTION } from "../test-constants";
 
 const configBucket = configStackName();
 
@@ -48,7 +49,7 @@ export const generateEventViaFilterLambdaAndCheckEventInS3Bucket = async (
 ): Promise<GenerateEventsResult> => {
   try {
     const updatedSQSEventPayload = await updateSQSEventPayloadBody(payload);
-    const functionName = `${resourcePrefix()}-filter-function`;
+    const functionName = FILTER_FUNCTION;
     await invokeLambda({ functionName, payload: updatedSQSEventPayload });
     const json = JSON.parse(updatedSQSEventPayload);
     const eventId = JSON.parse(json.Records[0].body).event_id;

--- a/src/handlers/int-test-support/helpers/testSetup.ts
+++ b/src/handlers/int-test-support/helpers/testSetup.ts
@@ -14,11 +14,13 @@ import {
 } from "../test-constants";
 
 export default async function globalSetup(): Promise<void> {
+  console.log("Cleaning up the environment before test execution starts");
   await deleteS3ObjectsAndPoll(STORAGE_BUCKET, `${S3_TRANSACTION_FOLDER}/2005`);
   await deleteS3ObjectsAndPoll(STORAGE_BUCKET, S3_INVOICE_FOLDER);
   await deleteS3ObjectsAndPoll(STORAGE_BUCKET, S3_INVOICE_ARCHIVED_FOLDER);
   await deleteAllObjects(RAW_INVOICE_BUCKET);
   await deleteAllObjects(RAW_INVOICE_TEXTRACT_BUCKET);
+  console.log("All previous data has been cleaned.");
 }
 
 const deleteS3ObjectsAndPoll = async (

--- a/src/handlers/int-test-support/helpers/testSetup.ts
+++ b/src/handlers/int-test-support/helpers/testSetup.ts
@@ -1,51 +1,62 @@
 import { poll } from "./commonHelpers";
-import { resourcePrefix } from "./envHelper";
-import { deleteS3ObjectsByPrefix, listS3Objects } from "./s3Helper";
-
-const prefix = resourcePrefix();
-const storageBucket = `${prefix}-storage`;
+import {
+  deleteS3Objects,
+  deleteS3ObjectsByPrefix,
+  listS3Objects,
+} from "./s3Helper";
+import {
+  S3_TRANSACTION_FOLDER,
+  STORAGE_BUCKET,
+  S3_INVOICE_FOLDER,
+  S3_INVOICE_ARCHIVED_FOLDER,
+  RAW_INVOICE_BUCKET,
+  RAW_INVOICE_TEXTRACT_BUCKET,
+} from "../test-constants";
 
 export default async function globalSetup(): Promise<void> {
-  // Delete objects with prefix "btm_event_data/2005"
-  await deleteS3ObjectsByPrefix({
-    bucket: storageBucket,
-    prefixes: ["btm_event_data/2005"],
-  });
+  await Promise.all([
+    deleteS3ObjectsAndPoll(STORAGE_BUCKET, `${S3_TRANSACTION_FOLDER}/2005`),
+    deleteS3ObjectsAndPoll(STORAGE_BUCKET, S3_INVOICE_FOLDER),
+    deleteS3ObjectsAndPoll(STORAGE_BUCKET, S3_INVOICE_ARCHIVED_FOLDER),
+    deleteAllObjects(RAW_INVOICE_BUCKET),
+    deleteAllObjects(RAW_INVOICE_TEXTRACT_BUCKET),
+  ]);
+}
+
+const deleteS3ObjectsAndPoll = async (
+  bucketName: string,
+  prefix: string
+): Promise<void> => {
+  await deleteS3ObjectsByPrefix({ bucket: bucketName, prefixes: [prefix] });
+
   // poll to ensure that the objects with prefix "btm_event_data/2005" have been deleted
   await poll(
     async () =>
       await listS3Objects({
-        bucketName: storageBucket,
-        prefix: "btm_event_data/2005",
+        bucketName,
+        prefix,
       }),
     (s3Objects) => s3Objects.length === 0,
     {
       timeout: 60000,
       interval: 10000,
-      notCompleteErrorMessage:
-        "btm_event_data/2005 folder could not be deleted because it still contains objects",
+      notCompleteErrorMessage: `${prefix} folder could not be deleted because it still contains objects`,
     }
   );
+};
 
-  // Delete objects with prefix "btm_invoice_data"
-  await deleteS3ObjectsByPrefix({
-    bucket: storageBucket,
-    prefixes: ["btm_invoice_data"],
-  });
+const deleteAllObjects = async (bucketName: string): Promise<void> => {
+  const s3Objects = await listS3Objects({ bucketName });
+  console.log(s3Objects);
+  if (s3Objects.length === 0) {
+    console.log("The bucket is empty. No folders to delete");
+    return;
+  }
+  for (const s3Object of s3Objects) {
+    if (typeof s3Object.key === "string") {
+      const key = s3Object.key;
 
-  // poll to ensure that the objects with prefix "btm_invoice_data" have been deleted
-  await poll(
-    async () =>
-      await listS3Objects({
-        bucketName: storageBucket,
-        prefix: "btm_invoice_data",
-      }),
-    (s3Objects) => s3Objects.length === 0,
-    {
-      timeout: 60000,
-      interval: 10000,
-      notCompleteErrorMessage:
-        "invoice_data folder could not be deleted because it still contains objects",
+      await deleteS3Objects({ bucket: bucketName, keys: [key] });
     }
-  );
-}
+  }
+};

--- a/src/handlers/int-test-support/test-constants.ts
+++ b/src/handlers/int-test-support/test-constants.ts
@@ -1,0 +1,22 @@
+import { resourcePrefix } from "./helpers/envHelper";
+
+export const VENDOR_SERVICE_CONFIG_PATH = "vendor_services/vendor-services.csv";
+export const E2E_TEST_CONFIG_PATH = "e2e-test.json";
+export const RATE_TABLE_CONFIG_PATH = "rate_tables/rates.csv";
+
+export const STORAGE_BUCKET = `${resourcePrefix()}-storage`;
+export const RAW_INVOICE_BUCKET = `${resourcePrefix()}-raw-invoice`;
+export const RAW_INVOICE_TEXTRACT_BUCKET = `${resourcePrefix()}-raw-invoice-textract-data`;
+export const TRANSACTION_CSV_BUCKET = `${resourcePrefix()}-transaction-csv`;
+
+export const FILTER_FUNCTION = `${resourcePrefix()}-filter-function`;
+export const CLEAN_FUNCTION = `${resourcePrefix()}-clean-function`;
+export const STORE_FUNCTION = `${resourcePrefix()}-storage-function`;
+export const INT_TEST_SUPPORT_FUNCTION = `${resourcePrefix()}-int-test-support-function`;
+
+export const S3_TRANSACTION_FOLDER = "btm_event_data";
+export const S3_INVOICE_FOLDER = "btm_invoice_data";
+export const S3_INVOICE_ARCHIVED_FOLDER = "btm_invoice_data_archived";
+
+export const DATABASE_NAME = `${resourcePrefix()}-calculations`;
+export const ATHENA_WORKGROUP = `${resourcePrefix()}-athena-workgroup`;


### PR DESCRIPTION
1. Removed the afterEach from standardised-line-item-tests as it was causing query failure when running the tests in parallel and moved the deletion to globalSetup function.
2. Refactored globalSetup function and included deleting raw-invoice and raw-invoice-textract-data bucket objects.
3. Created file called test-constants to  manage the constant values throughout the tests for ease of maintenance.
4. Increased test timeout and checkStandardised poll timeout  to allow more time for the invoice to appear in standardised folder.