### PR TITLE
Added longer wait when fetching view results, and longer timeout

### DIFF
--- a/cloudformation/dashboard-data-extraction.yaml
+++ b/cloudformation/dashboard-data-extraction.yaml
@@ -23,7 +23,7 @@ Resources:
           POWERTOOLS_SERVICE_NAME: !Sub ${AWS::StackName}-dashboard-extract-function
       Handler: dashboardExtract.handler
       KmsKeyArn: !GetAtt KmsKey.Arn
-      Timeout: 120
+      Timeout: 180
       Policies:
         - AWSLambdaVPCAccessExecutionRole
         - Statement:

--- a/src/handlers/dashboard-extract/fetch-view-data.ts
+++ b/src/handlers/dashboard-extract/fetch-view-data.ts
@@ -6,10 +6,12 @@ import { AthenaQueryExecutor } from "../../shared/utils/athena";
 
 const athena = new Athena({ region: "eu-west-2" });
 
+const QUERY_WAIT = 30 * 1000; // Thirty seconds
+
 export async function fetchViewData(
   env: Record<Env, string>
 ): Promise<ResultSet> {
   const fetchDataSql = `SELECT * FROM "${env.DATABASE_NAME}".btm_billing_and_transactions_curated`;
-  const executor = new AthenaQueryExecutor(athena);
+  const executor = new AthenaQueryExecutor(athena, QUERY_WAIT);
   return await executor.fetchResults(fetchDataSql, env.QUERY_RESULTS_BUCKET);
 }

--- a/src/shared/utils/athena.ts
+++ b/src/shared/utils/athena.ts
@@ -1,13 +1,17 @@
 import { Athena } from "aws-sdk/clients/all";
 
+const INTERVAL_MS = 1000;
+
 export class AthenaQueryExecutor {
   athena: Athena;
 
-  INTERVAL_MS = 1000;
+  intervalMillis: number;
+
   MAX_ATTEMPTS = 10;
 
-  constructor(athena: Athena) {
+  constructor(athena: Athena, intervalMillis = INTERVAL_MS) {
     this.athena = athena;
+    this.intervalMillis = intervalMillis;
   }
 
   async fetchResults(
@@ -80,7 +84,9 @@ export class AthenaQueryExecutor {
           `Unrecognised query execution state: ${queryExecutionState}`
         );
 
-      await new Promise((resolve) => setTimeout(resolve, this.INTERVAL_MS));
+      console.log(`Continuing to wait after ${queryExecutionState} received.`);
+
+      await new Promise((resolve) => setTimeout(resolve, this.intervalMillis));
     }
 
     throw new Error(


### PR DESCRIPTION
Using validate() to verify the view query results resulted in it doing 10 tries with a 1-second wait in between, which was not long enough to complete the view query.  So this change allows for a longer wait in this instance.

Also bumped the lambda timeout to 3 minutes, so we don't suddenly start getting timeouts in (say) six months when we have more data in the system.