### PR TITLE
BTM-586 Join transactions to billing on event_name

### DIFF
--- a/cloudformation/calculation-athena.yaml
+++ b/cloudformation/calculation-athena.yaml
@@ -241,11 +241,11 @@ Resources:
         Name: btm_billing_and_transactions_curated
         Query: !Sub |
           SELECT
-            txn.vendor_id
-            , txn.vendor_name
-            , txn.service_name
-            , txn.year
-            , txn.month
+            COALESCE(txn.vendor_id, invoice.vendor_id) vendor_id
+            , COALESCE(txn.vendor_name, invoice.vendor_name) vendor_name
+            , COALESCE(txn.service_name, invoice.service_name) service_name
+            , COALESCE(txn.year, invoice.year) year
+            , COALESCE(txn.month, invoice.month) month
             , CONCAT('£', REGEXP_REPLACE(CAST(CAST(invoice.price AS DECIMAL(10,2)) AS VARCHAR), '(\d)(?=(\d{3})+\.)', '$1,')) billing_price_formatted
             , CONCAT('£', REGEXP_REPLACE(CAST(CAST(txn.price AS DECIMAL(10,2)) AS VARCHAR), '(\d)(?=(\d{3})+\.)', '$1,')) transaction_price_formatted
             , CONCAT('£', REGEXP_REPLACE(CAST(CAST((invoice.price - txn.price) AS decimal(10,2)) AS varchar), '(\d)(?=(\d{3})+\.)', '$1,')) price_difference

--- a/cloudformation/calculation-athena.yaml
+++ b/cloudformation/calculation-athena.yaml
@@ -215,6 +215,7 @@ Resources:
                             AND (txn.timestamp BETWEEN rates.effective_from AND COALESCE(rates.effective_to, "From_iso8601_timestamp"('2049-12-31')))))
           SELECT "MAX"(vendor_id)        vendor_id,
                 "MAX"(vendor_name)       vendor_name,
+                "MAX"(event_name)        event_name,
                 "MAX"(service_name)      service_name,
                 "SUM"(transaction_price) price,
                 "COUNT"(event_id)        quantity,
@@ -240,11 +241,11 @@ Resources:
         Name: btm_billing_and_transactions_curated
         Query: !Sub |
           SELECT
-            COALESCE(invoice.vendor_id, txn.vendor_id) vendor_id
-            , COALESCE(invoice.vendor_name, txn.vendor_name) vendor_name
-            , COALESCE(invoice.service_name, txn.service_name) service_name
-            , COALESCE(invoice.year, txn.year) year
-            , COALESCE(invoice.month, txn.month) month
+            txn.vendor_id
+            , txn.vendor_name
+            , txn.service_name
+            , txn.year
+            , txn.month
             , CONCAT('£', REGEXP_REPLACE(CAST(CAST(invoice.price AS DECIMAL(10,2)) AS VARCHAR), '(\d)(?=(\d{3})+\.)', '$1,')) billing_price_formatted
             , CONCAT('£', REGEXP_REPLACE(CAST(CAST(txn.price AS DECIMAL(10,2)) AS VARCHAR), '(\d)(?=(\d{3})+\.)', '$1,')) transaction_price_formatted
             , CONCAT('£', REGEXP_REPLACE(CAST(CAST((invoice.price - txn.price) AS decimal(10,2)) AS varchar), '(\d)(?=(\d{3})+\.)', '$1,')) price_difference
@@ -259,7 +260,7 @@ Resources:
               (btm_transactions_curated txn
                 FULL JOIN btm_billing_curated invoice ON
                       ((((txn.vendor_id = invoice.vendor_id) AND
-                      (txn.service_name = invoice.service_name)) AND
+                      (txn.event_name = invoice.event_name)) AND
                       (txn.year = invoice.year)) AND
                       (txn.month = invoice.month)))
         Workgroup: !Ref AthenaTransactionWorkgroup

--- a/cloudformation/invoice-athena.yaml
+++ b/cloudformation/invoice-athena.yaml
@@ -100,6 +100,8 @@ Resources:
               Type: int
             - Name: price
               Type: decimal(12,4)
+            - Name: event_name
+              Type: string
           Compressed: 'true'
           InputFormat: org.apache.hadoop.mapred.TextInputFormat
           Location: !Sub s3://${StorageBucket}/btm_invoice_data/
@@ -124,11 +126,12 @@ Resources:
             vendor_id,
             vendor_name,
             service_name,
+            event_name,
             sum(quantity) AS quantity,
             sum(price) AS price,
             sum(tax) AS tax,
             year,
             month
           FROM btm_billing_standardised
-          GROUP BY vendor_id,vendor_name,service_name,year,month
+          GROUP BY vendor_id,vendor_name,service_name,event_name,year,month
         Workgroup: !Ref AthenaInvoiceWorkgroup


### PR DESCRIPTION
Previously, the `BillingAndTransactionsCuratedView` joined joined transactions and billing on vendor_id, service_name, year and month. The service_name is also displayed on Grafana and changing this value breaks the join.
Therefore, this PR joins on the event_name which is already stored in our standardised invoice data. 