### PR TITLE
BTM-600: allow email sender verification

### DIFF
--- a/cloudformation/email-storage.yaml
+++ b/cloudformation/email-storage.yaml
@@ -39,8 +39,9 @@ Resources:
                 aws:SecureTransport: true
               StringEquals:
                 aws:SourceAccount: !Ref AWS::AccountId
-                aws:SourceArn:
-                  - !If
-                    - IsDev
+                aws:SourceArn: !If
+                  - IsDev
+                  - - !Sub arn:aws:ses:eu-west-1:${AWS::AccountId}:receipt-rule-set/di-btm-tooling-email-dev-receipt-rule-set:receipt-rule/di-btm-tooling-email-dev-sender-verification-receipt-rule
                     - !Sub arn:aws:ses:eu-west-1:${AWS::AccountId}:receipt-rule-set/di-btm-tooling-email-dev-receipt-rule-set:receipt-rule/di-btm-tooling-email-dev-vendor1-receipt-rule
+                  - - !Sub arn:aws:ses:eu-west-1:${AWS::AccountId}:receipt-rule-set/di-btm-tooling-email-${Environment}-receipt-rule-set:receipt-rule/di-btm-tooling-email-${Environment}-sender-verification-receipt-rule
                     - !Sub arn:aws:ses:eu-west-1:${AWS::AccountId}:receipt-rule-set/di-btm-tooling-email-${Environment}-receipt-rule-set:receipt-rule/di-btm-tooling-email-${Environment}-vendor1-receipt-rule

--- a/package.json
+++ b/package.json
@@ -66,7 +66,8 @@
     "sam:build": "npm run build && npm run build:template && npm run checkov && sam build",
     "sam:deploy": "sam deploy --disable-rollback --no-fail-on-empty-changeset --stack-name di-btm-${ENV_NAME} --parameter-overrides Environment=dev PrivateConfigStack=${CONFIG_NAME:-none} TestRoleArn=${TEST_ROLE_ARN:-none} EnableAlerting=${ENABLE_ALERTING:-false} --s3-prefix ${ENV_NAME}",
     "sam:teardown": "ts-node --esm src/tools/teardown-cf-stack.ts",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "fetch-s3": "NODE_OPTIONS=--es-module-specifier-resolution=node ts-node --esm src/tools/fetch-s3.ts"
   },
   "lint-staged": {
     "*.{js,ts}": "eslint --fix",

--- a/src/handlers/process-email/business-logic.test.ts
+++ b/src/handlers/process-email/business-logic.test.ts
@@ -32,15 +32,19 @@ describe("process-email business logic", () => {
       businessLogic(validIncomingEventBody, mockContext, invalidMockMeta)
     ).rejects.toThrowError("Missing bucketName and/or key");
   });
-  test("should throw error with event record that has no vendor ID folder", async () => {
-    const invalidMockMeta = {
+  test("should return empty array with event record that has no vendor ID folder", async () => {
+    const mockMeta = {
       bucketName: "given bucket name",
       key: "given-file-path-with-no-folder",
     };
 
-    await expect(
-      businessLogic(validIncomingEventBody, mockContext, invalidMockMeta)
-    ).rejects.toThrowError("File not in vendor ID folder");
+    const result = await businessLogic(
+      validIncomingEventBody,
+      mockContext,
+      mockMeta
+    );
+
+    expect(result).toEqual([]);
   });
 
   test("should return attachments that are pdf or csv ", async () => {

--- a/src/handlers/process-email/business-logic.ts
+++ b/src/handlers/process-email/business-logic.ts
@@ -8,15 +8,19 @@ export const businessLogic: BusinessLogic<
   never,
   EmailAttachment
 > = async (event, { logger }, meta) => {
-  // File must be in a vendor ID folder in the Raw Email bucket, which determines folder for the Raw Invoice bucket. Throw error otherwise.
+  // Invoice email file must be in a vendor ID folder in the Raw Email bucket, which determines folder for the Raw Invoice bucket
+  // If it is not in a folder, assume it is an email sent by Amazon to verify a sender address and ignore it
   let vendorId: string;
   let sourceFileName: string;
   if (meta?.key && meta?.bucketName) {
     const filePathParts = meta.key.split("/");
-    if (filePathParts.length < 2)
-      throw Error(
+
+    if (filePathParts.length < 2) {
+      logger.info(
         `File not in vendor ID folder: ${meta.bucketName}/${meta.key}`
       );
+      return [];
+    }
 
     vendorId = filePathParts[0];
     sourceFileName = filePathParts[filePathParts.length - 1];

--- a/src/shared/utils/kms/client.ts
+++ b/src/shared/utils/kms/client.ts
@@ -1,6 +1,6 @@
-import { KMS } from "aws-sdk";
+import AWS from "aws-sdk";
 
-export const kms = new KMS({
+export const kms = new AWS.KMS({
   region: "eu-west-2",
   endpoint: process.env.LOCAL_ENDPOINT,
 });

--- a/src/shared/utils/kms/index.ts
+++ b/src/shared/utils/kms/index.ts
@@ -1,11 +1,11 @@
-import { KMS } from "aws-sdk";
+import AWS from "aws-sdk";
 import { Blob } from "node:buffer";
 import { TextEncoder } from "node:util";
 import { kms } from "./client";
 
 export const decryptKms = async (
   encryptedBytes: Uint8Array,
-  context: KMS.EncryptionContextType
+  context: AWS.KMS.EncryptionContextType
 ): Promise<Uint8Array> => {
   const request = {
     CiphertextBlob: encryptedBytes,

--- a/src/tools/fetch-s3.ts
+++ b/src/tools/fetch-s3.ts
@@ -1,0 +1,14 @@
+import { fetchS3 } from "../shared/utils";
+
+const arg = process.argv[process.argv.length - 1];
+
+const [bucketName, ...filePathParts] = arg.split("/");
+
+if (filePathParts.length === 0)
+  throw Error("Expected argument format `bucket-name/path/to/file`");
+
+const filePath = filePathParts.join("/");
+
+const fileText = await fetchS3(bucketName, filePath);
+
+console.log(fileText);


### PR DESCRIPTION
This lets us send email with Simple Email Service to the invoice inbox

Sending email with SES requires the sender email address to be verified by opening a URL in an email sent to that address, so this PR allows email sent to that address to be received, and it adds a command line script to print decrypted email so that the URL can be manually found and opened

Note: the way we have been running TypeScript scripts from the command line does not seem to support all of the same import syntax that our Lambdas do for all of the module systems that our dependencies use. In particular, our code was apparently using a nonstandard way to import a property of the default export of a CommonJS module, so I changed the syntax in the relevant places to one supported by both Lambdas and scripts