### PR TITLE
BTM-591 Part 1 Reconciliation table

### DIFF
--- a/cloudformation/calculation-athena.yaml
+++ b/cloudformation/calculation-athena.yaml
@@ -313,7 +313,7 @@ Resources:
                 WHEN ((invoice.price IS NULL) AND (invoice.quantity IS NULL)) THEN ${QueryMessageInvoiceDataMissing}
                 WHEN ((txn.price IS NULL) AND (txn.quantity IS NULL)) THEN ${QueryMessageTransactionDataMissing}
                 WHEN (txn.price IS NULL) THEN ${QueryMessageRateCardDataMissing}
-                WHEN (COALESCE(txn.price, 0) = 0) THEN (CASE WHEN (COALESCE(invoice.price, 0) = 0) THEN 0 ELSE ${QueryMessageUnexpectedInvoiceCharge} END)
+                WHEN (COALESCE(txn.price, 0) = 0) THEN (CASE WHEN (COALESCE(invoice.price, 0) = 0) THEN 0 ELSE ${UnexpectedInvoiceCharge} END)
                 ELSE ((100 * (COALESCE(invoice.price, 0) - txn.price)) / txn.price)
               END) price_difference_percentage
           FROM

--- a/cloudformation/calculation-athena.yaml
+++ b/cloudformation/calculation-athena.yaml
@@ -41,6 +41,12 @@ Resources:
               Type: string
             - Name: price_difference
               Type: string
+            - Name: transaction_quantity
+              Type: string
+            - Name: invoice_quantity
+              Type: string
+            - Name: quantity_difference
+              Type: string
             - Name: billing_amount_with_tax
               Type: string
             - Name: price_difference_percentage
@@ -298,13 +304,16 @@ Resources:
             , CONCAT('£', REGEXP_REPLACE(CAST(CAST(invoice.price AS DECIMAL(10,2)) AS VARCHAR), '(\d)(?=(\d{3})+\.)', '$1,')) billing_price_formatted
             , CONCAT('£', REGEXP_REPLACE(CAST(CAST(txn.price AS DECIMAL(10,2)) AS VARCHAR), '(\d)(?=(\d{3})+\.)', '$1,')) transaction_price_formatted
             , CONCAT('£', REGEXP_REPLACE(CAST(CAST((invoice.price - txn.price) AS decimal(10,2)) AS varchar), '(\d)(?=(\d{3})+\.)', '$1,')) price_difference
+            , txn.quantity transaction_quantity
+            , invoice.quantity invoice_quantity
+            , REGEXP_REPLACE(CAST(CAST((invoice.quantity - txn.quantity) AS decimal(10,2)) AS varchar), '(\d)(?=(\d{3})+\.)', '$1,') quantity_difference
             , CONCAT('£', REGEXP_REPLACE(CAST(CAST((invoice.price + invoice.tax) AS decimal(10,2)) AS varchar), '(\d)(?=(\d{3})+\.)', '$1,')) billing_amount_with_tax
             , (CASE
                 WHEN ((invoice.price = 0) AND (txn.price = 0)) THEN ${QueryMessageNoChargeForThisMonth}
                 WHEN ((invoice.price IS NULL) AND (invoice.quantity IS NULL)) THEN ${QueryMessageInvoiceDataMissing}
                 WHEN ((txn.price IS NULL) AND (txn.quantity IS NULL)) THEN ${QueryMessageTransactionDataMissing}
                 WHEN (txn.price IS NULL) THEN ${QueryMessageRateCardDataMissing}
-                WHEN (COALESCE(txn.price, 0) = 0) THEN (CASE WHEN (COALESCE(invoice.price, 0) = 0) THEN 0 ELSE ${UnexpectedInvoiceCharge} END)
+                WHEN (COALESCE(txn.price, 0) = 0) THEN (CASE WHEN (COALESCE(invoice.price, 0) = 0) THEN 0 ELSE ${QueryMessageUnexpectedInvoiceCharge} END)
                 ELSE ((100 * (COALESCE(invoice.price, 0) - txn.price)) / txn.price)
               END) price_difference_percentage
           FROM

--- a/cloudformation/calculation-athena.yaml
+++ b/cloudformation/calculation-athena.yaml
@@ -41,9 +41,9 @@ Resources:
               Type: string
             - Name: price_difference
               Type: string
-            - Name: transaction_quantity
+            - Name: billing_quantity
               Type: string
-            - Name: invoice_quantity
+            - Name: transaction_quantity
               Type: string
             - Name: quantity_difference
               Type: string
@@ -304,8 +304,8 @@ Resources:
             , CONCAT('£', REGEXP_REPLACE(CAST(CAST(invoice.price AS DECIMAL(10,2)) AS VARCHAR), '(\d)(?=(\d{3})+\.)', '$1,')) billing_price_formatted
             , CONCAT('£', REGEXP_REPLACE(CAST(CAST(txn.price AS DECIMAL(10,2)) AS VARCHAR), '(\d)(?=(\d{3})+\.)', '$1,')) transaction_price_formatted
             , CONCAT('£', REGEXP_REPLACE(CAST(CAST((invoice.price - txn.price) AS decimal(10,2)) AS varchar), '(\d)(?=(\d{3})+\.)', '$1,')) price_difference
+            , invoice.quantity billing_quantity
             , txn.quantity transaction_quantity
-            , invoice.quantity invoice_quantity
             , REGEXP_REPLACE(CAST(CAST((invoice.quantity - txn.quantity) AS decimal(10,2)) AS varchar), '(\d)(?=(\d{3})+\.)', '$1,') quantity_difference
             , CONCAT('£', REGEXP_REPLACE(CAST(CAST((invoice.price + invoice.tax) AS decimal(10,2)) AS varchar), '(\d)(?=(\d{3})+\.)', '$1,')) billing_amount_with_tax
             , (CASE

--- a/cloudformation/frontend.yaml
+++ b/cloudformation/frontend.yaml
@@ -21,6 +21,7 @@ Resources:
     Properties:
       KmsKeyId: !GetAtt KmsKey.Arn
       RetentionInDays: 90
+      LogGroupName: !Sub '/aws/vendedlogs/${AWS::StackName}-FE-API-Log-Group'
 
   FrontEndAuthFunction:
     # checkov:skip=CKV_AWS_116: DLQ not needed for front end lambda


### PR DESCRIPTION
This PR adds the new fields to full-extract.json that will be needed for the UI for BTM-591, 589 and 650.

It also adds /`aws/vendedlogs/` to the FrontEndApiLogGroup to avoid breaking Cloudwatch Logs Constraints. Documentation [here](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/AWS-logs-and-resource-policy.html#AWS-logs-infrastructure-CWL).  