### PR TITLE
BTM-590 UI Quantity (events) data table

### DIFF
--- a/cloudformation/calculation-athena.yaml
+++ b/cloudformation/calculation-athena.yaml
@@ -306,7 +306,7 @@ Resources:
             , CONCAT('£', REGEXP_REPLACE(CAST(CAST((invoice.price - txn.price) AS decimal(10,2)) AS varchar), '(\d)(?=(\d{3})+\.)', '$1,')) price_difference
             , invoice.quantity billing_quantity
             , txn.quantity transaction_quantity
-            , REGEXP_REPLACE(CAST(CAST((invoice.quantity - txn.quantity) AS decimal(10,2)) AS varchar), '(\d)(?=(\d{3})+\.)', '$1,') quantity_difference
+            , REGEXP_REPLACE(CAST(invoice.quantity - txn.quantity AS varchar), '(\d)(?=(\d{3})+\.)', '$1,') quantity_difference
             , CONCAT('£', REGEXP_REPLACE(CAST(CAST((invoice.price + invoice.tax) AS decimal(10,2)) AS varchar), '(\d)(?=(\d{3})+\.)', '$1,')) billing_amount_with_tax
             , (CASE
                 WHEN ((invoice.price = 0) AND (txn.price = 0)) THEN ${QueryMessageNoChargeForThisMonth}

--- a/integration_tests/tests/dashboard-data-extraction-tests.ts
+++ b/integration_tests/tests/dashboard-data-extraction-tests.ts
@@ -79,9 +79,6 @@ describe("\n DashboardDataExtractFunction", () => {
     expect(response[0].service_name).toEqual(
       standardisedInvoiceObject.service_name
     );
-    expect(response[0].service_name).toEqual(
-      standardisedInvoiceObject.service_name
-    );
     expect(response[0].contract_id).toEqual(
       standardisedInvoiceObject.contract_id
     );
@@ -98,6 +95,11 @@ describe("\n DashboardDataExtractFunction", () => {
     );
     expect(response[0].transaction_price_formatted).toEqual("");
     expect(response[0].price_difference).toEqual("");
+    expect(response[0].billing_quantity).toEqual(
+      standardisedInvoiceObject.quantity.toString()
+    );
+    expect(response[0].transaction_quantity).toEqual("");
+    expect(response[0].quantity_difference).toEqual("");
     expect(response[0].billing_amount_with_tax).toEqual(
       standardisedInvoiceObject.total.toLocaleString("en-GB", {
         style: "currency",
@@ -119,6 +121,9 @@ interface BtmMonthlyExtract {
   billing_price_formatted: string;
   transaction_price_formatted: string;
   price_difference: string;
+  billing_quantity: string;
+  transaction_quantity: string;
+  quantity_difference: string;
   billing_amount_with_tax: string;
   price_difference_percentage: number;
 }

--- a/src/frontend/extract-helper.test.ts
+++ b/src/frontend/extract-helper.test.ts
@@ -101,7 +101,7 @@ describe("extract helper", () => {
   });
 
   describe("getReconciliationRows", () => {
-    test("Should return the data for the Reconciliation Table", async () => {
+    test("Should return the data for the Reconciliation Table when all billing and transaction data is available", async () => {
       // Arrange
       const givenLineItems = [
         {
@@ -132,6 +132,160 @@ describe("extract helper", () => {
             statusMessage: "Below Threshold",
             statusClasses: "govuk-tag--blue",
           },
+          billingQuantity: "2",
+          transactionQuantity: "11",
+        },
+      ];
+      // Act
+      const result = getReconciliationRows(givenLineItems);
+      // Assert
+      expect(result).toEqual(expectedReconciliationRow);
+    });
+
+    test("Should return the data for the Reconciliation Table when Invoice data is missing", async () => {
+      // Arrange
+      const givenLineItems = [
+        {
+          vendor_id: "vendor_testvendor4",
+          vendor_name: "Vendor Four",
+          service_name: "Passport check",
+          contract_id: "4",
+          contract_name: "FOOBAR1",
+          year: "2005",
+          month: "02",
+          billing_price_formatted: "",
+          transaction_price_formatted: "£27.50",
+          price_difference: "",
+          billing_quantity: "",
+          transaction_quantity: "11",
+          quantity_difference: "",
+          billing_amount_with_tax: "",
+          price_difference_percentage: "-1234567.03",
+        },
+      ];
+      const expectedReconciliationRow = [
+        {
+          serviceName: "Passport check",
+          quantityDiscrepancy: "",
+          priceDiscrepancy: "",
+          percentageDiscrepancy: "Invoice data missing",
+          status: {
+            statusMessage: "Pending",
+            statusClasses: "govuk-tag--grey",
+          },
+          billingQuantity: "Invoice data missing",
+          transactionQuantity: "11",
+        },
+      ];
+      // Act
+      const result = getReconciliationRows(givenLineItems);
+      // Assert
+      expect(result).toEqual(expectedReconciliationRow);
+    });
+
+    test("Should return the data for the Reconciliation Table when transaction events are missing", async () => {
+      // Arrange
+      const givenLineItems = [
+        {
+          vendor_id: "vendor_testvendor4",
+          vendor_name: "Vendor Four",
+          service_name: "Passport check",
+          contract_id: "4",
+          contract_name: "FOOBAR1",
+          year: "2005",
+          month: "02",
+          billing_price_formatted: "£96",
+          transaction_price_formatted: "",
+          price_difference: "",
+          billing_quantity: "300",
+          transaction_quantity: "",
+          quantity_difference: "",
+          billing_amount_with_tax: "£116.10",
+          price_difference_percentage: "-1234567.04",
+        },
+      ];
+      const expectedReconciliationRow = [
+        {
+          serviceName: "Passport check",
+          quantityDiscrepancy: "",
+          priceDiscrepancy: "",
+          percentageDiscrepancy: "Events missing",
+          status: {
+            statusMessage: "Error",
+            statusClasses: "govuk-tag--grey",
+          },
+          billingQuantity: "300",
+          transactionQuantity: "Events missing",
+        },
+      ];
+      // Act
+      const result = getReconciliationRows(givenLineItems);
+      // Assert
+      expect(result).toEqual(expectedReconciliationRow);
+    });
+
+    test("Should return the data for the Reconciliation Table when there are two line items, one with an unexpected invoice charge and one within threshold.", async () => {
+      // Arrange
+      const givenLineItems = [
+        {
+          vendor_id: "vendor_testvendor4",
+          vendor_name: "Vendor Four",
+          service_name: "Passport check",
+          contract_id: "4",
+          contract_name: "FOOBAR1",
+          year: "2005",
+          month: "02",
+          billing_price_formatted: "£27.50",
+          transaction_price_formatted: "0.00",
+          price_difference: "£27.50",
+          billing_quantity: "11",
+          transaction_quantity: "2",
+          quantity_difference: "9",
+          billing_amount_with_tax: "£30.00",
+          price_difference_percentage: "-1234567.05",
+        },
+        {
+          vendor_id: "vendor_testvendor4",
+          vendor_name: "Vendor Four",
+          service_name: "Standard Charge",
+          contract_id: "4",
+          contract_name: "FOOBAR1",
+          year: "2005",
+          month: "02",
+          billing_price_formatted: "£100.00",
+          transaction_price_formatted: "100.00",
+          price_difference: "£0.00",
+          billing_quantity: "11",
+          transaction_quantity: "11",
+          quantity_difference: "0",
+          billing_amount_with_tax: "£105.00",
+          price_difference_percentage: "0.0",
+        },
+      ];
+      const expectedReconciliationRow = [
+        {
+          serviceName: "Passport check",
+          quantityDiscrepancy: "9",
+          priceDiscrepancy: "£27.50",
+          percentageDiscrepancy: "Unexpected invoice charge",
+          status: {
+            statusMessage: "Above Threshold",
+            statusClasses: "govuk-tag--red",
+          },
+          billingQuantity: "11",
+          transactionQuantity: "2",
+        },
+        {
+          serviceName: "Standard Charge",
+          quantityDiscrepancy: "0",
+          priceDiscrepancy: "£0.00",
+          percentageDiscrepancy: "0.0%",
+          status: {
+            statusMessage: "Within Threshold",
+            statusClasses: "govuk-tag--green",
+          },
+          billingQuantity: "11",
+          transactionQuantity: "11",
         },
       ];
       // Act

--- a/src/frontend/extract-helper.test.ts
+++ b/src/frontend/extract-helper.test.ts
@@ -127,7 +127,7 @@ describe("extract helper", () => {
           serviceName: "Passport check",
           quantityDiscrepancy: "-9",
           priceDiscrepancy: "£-27.50",
-          percentageDiscrepancy: "-100.0",
+          percentageDiscrepancy: "-100.0%",
           status: {
             statusMessage: "Below Threshold",
             statusClasses: "govuk-tag--blue",

--- a/src/frontend/extract-helper.ts
+++ b/src/frontend/extract-helper.ts
@@ -102,7 +102,7 @@ const getPercentageDiscrepancyMessage = (
   return (
     PERCENTAGE_DISCREPANCY.find(
       (discrepancy) => discrepancy.magicNumber === percentageDiscrepancy
-    )?.bannerText ?? percentageDiscrepancy
+    )?.bannerText ?? percentageDiscrepancy + "%"
   );
 };
 

--- a/src/frontend/extract-helper.ts
+++ b/src/frontend/extract-helper.ts
@@ -108,7 +108,7 @@ const getPercentageDiscrepancyMessage = (
 
 const getStatus = (percentageDiscrepancy: string): StatusLabel => {
   const warning = PERCENTAGE_DISCREPANCY.find(
-    (situation) => situation.magicNumber === percentageDiscrepancy
+    (discrepancy) => discrepancy.magicNumber === percentageDiscrepancy
   );
   if (warning) return warning.statusLabel;
   if (+percentageDiscrepancy >= 1) return STATUS_LABEL_ABOVE_THRESHOLD;

--- a/src/frontend/extract-helper.ts
+++ b/src/frontend/extract-helper.ts
@@ -86,6 +86,8 @@ interface ReconciliationRow {
   priceDiscrepancy: string;
   percentageDiscrepancy: string;
   status: StatusLabel;
+  billingQuantity: string;
+  transactionQuantity: string;
 }
 
 const PERCENTAGE_DISCREPANCY = [
@@ -104,6 +106,17 @@ const getPercentageDiscrepancyMessage = (
       (discrepancy) => discrepancy.magicNumber === percentageDiscrepancy
     )?.bannerText ?? percentageDiscrepancy + "%"
   );
+};
+
+const getQuantity = (
+  quantity: string,
+  percentageDiscrepancy: string
+): string => {
+  return quantity !== ""
+    ? quantity
+    : PERCENTAGE_DISCREPANCY.find(
+        (discrepancy) => discrepancy.magicNumber === percentageDiscrepancy
+      )?.bannerText ?? "";
 };
 
 const getStatus = (percentageDiscrepancy: string): StatusLabel => {
@@ -129,6 +142,14 @@ export const getReconciliationRows = (
         item.price_difference_percentage
       ),
       status: getStatus(item.price_difference_percentage),
+      billingQuantity: getQuantity(
+        item.billing_quantity,
+        item.price_difference_percentage
+      ),
+      transactionQuantity: getQuantity(
+        item.transaction_quantity,
+        item.price_difference_percentage
+      ),
     };
     rows.push(row);
   }

--- a/src/frontend/handlers/__snapshots__/invoice.test.ts.snap
+++ b/src/frontend/handlers/__snapshots__/invoice.test.ts.snap
@@ -128,6 +128,7 @@ exports[`invoice handler Page displays invoice page header 1`] = `
 </div>
 
   <table class="govuk-table">
+    <caption class="govuk-table__caption govuk-table__caption--m">Reconciliation</caption>
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
         <th class="govuk-table__header" scope="col">Line Item</th>
@@ -150,6 +151,27 @@ exports[`invoice handler Page displays invoice page header 1`] = `
 </strong>
 
           </td>
+        </tr>
+      </tbody>
+    
+  </table>
+  <table class="govuk-table">
+    <caption class="govuk-table__caption govuk-table__caption--m">Quantity (events)</caption>
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th class="govuk-table__header" scope="col">Line Item</th>
+        <th class="govuk-table__header" scope="col">Invoiced Quantity</th>
+        <th class="govuk-table__header" scope="col">Measured Quantity</th>
+        <th class="govuk-table__header" scope="col">Quantity Discrepancy</th>
+      </tr>
+    </thead>
+    
+      <tbody class="govuk-table__body">
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">Passport check</td>
+          <td class="govuk-table__cell">2</td>
+          <td class="govuk-table__cell">11</td>
+          <td class="govuk-table__cell">-9</td>
         </tr>
       </tbody>
     

--- a/src/frontend/handlers/__snapshots__/invoice.test.ts.snap
+++ b/src/frontend/handlers/__snapshots__/invoice.test.ts.snap
@@ -143,7 +143,7 @@ exports[`invoice handler Page displays invoice page header 1`] = `
           <td class="govuk-table__cell">Passport check</td>
           <td class="govuk-table__cell">-9</td>
           <td class="govuk-table__cell"></td>
-          <td class="govuk-table__cell">0</td>
+          <td class="govuk-table__cell">0%</td>
           <td class="govuk-table__cell">
             <strong class="govuk-tag govuk-tag--green">
   Within Threshold

--- a/src/frontend/views/invoice.njk
+++ b/src/frontend/views/invoice.njk
@@ -33,6 +33,7 @@
     classes: classes
     }) }}
   <table class="govuk-table">
+    <caption class="govuk-table__caption govuk-table__caption--m">Reconciliation</caption>
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
         <th class="govuk-table__header" scope="col">Line Item</th>
@@ -55,6 +56,27 @@
                         classes: row.status.statusClasses
                         }) }}
           </td>
+        </tr>
+      </tbody>
+    {% endfor %}
+  </table>
+  <table class="govuk-table">
+    <caption class="govuk-table__caption govuk-table__caption--m">Quantity (events)</caption>
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th class="govuk-table__header" scope="col">Line Item</th>
+        <th class="govuk-table__header" scope="col">Invoiced Quantity</th>
+        <th class="govuk-table__header" scope="col">Measured Quantity</th>
+        <th class="govuk-table__header" scope="col">Quantity Discrepancy</th>
+      </tr>
+    </thead>
+    {% for row in reconciliationRows %}
+      <tbody class="govuk-table__body">
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">{{ row.serviceName }}</td>
+          <td class="govuk-table__cell">{{ row.billingQuantity }}</td>
+          <td class="govuk-table__cell">{{ row.transactionQuantity }}</td>
+          <td class="govuk-table__cell">{{ row.quantityDiscrepancy }}</td>
         </tr>
       </tbody>
     {% endfor %}


### PR DESCRIPTION
UI for the Quantity (events) table. Design can be found [here](https://app.moqups.com/DpSOLhFxFMD222IpkWjpPj8BHy6BhoyE/edit/page/a179ad680) and [this URL](https://3lcq36ez1i.execute-api.eu-west-2.amazonaws.com/invoices?contract_id=1) is for this PR stack with multi line examples under Vendor One.

Example Screenshot:

![image](https://github.com/alphagov/di-billing-transaction-monitoring/assets/116570124/0369092f-f70a-4fc0-900f-0cdccf96dbb5)

