### PR TITLE
BTM-589 UI Invoice Details Table

### DIFF
--- a/cloudformation/calculation-athena.yaml
+++ b/cloudformation/calculation-athena.yaml
@@ -35,6 +35,8 @@ Resources:
               Type: string
             - Name: month
               Type: string
+            - Name: billing_unit_price
+              Type: string
             - Name: billing_price_formatted
               Type: string
             - Name: transaction_price_formatted
@@ -301,14 +303,14 @@ Resources:
             , COALESCE(txn.contract_name, invoice.contract_name) contract_name
             , COALESCE(txn.year, invoice.year) year
             , COALESCE(txn.month, invoice.month) month
-            , invoice.unit_price billing_unit_price
+            , CONCAT('£', (CAST(CAST(invoice.unit_price AS DECIMAL(12, 4)) AS VARCHAR))) billing_unit_price
             , CONCAT('£', REGEXP_REPLACE(CAST(CAST(invoice.price AS DECIMAL(10,2)) AS VARCHAR), '(\d)(?=(\d{3})+\.)', '$1,')) billing_price_formatted
             , CONCAT('£', REGEXP_REPLACE(CAST(CAST(txn.price AS DECIMAL(10,2)) AS VARCHAR), '(\d)(?=(\d{3})+\.)', '$1,')) transaction_price_formatted
-            , CONCAT('£', REGEXP_REPLACE(CAST(CAST((invoice.price - txn.price) AS decimal(10,2)) AS varchar), '(\d)(?=(\d{3})+\.)', '$1,')) price_difference
+            , CONCAT('£', REGEXP_REPLACE(CAST(CAST((invoice.price - txn.price) AS decimal(10,2)) AS VARCHAR), '(\d)(?=(\d{3})+\.)', '$1,')) price_difference
             , invoice.quantity billing_quantity
             , txn.quantity transaction_quantity
-            , REGEXP_REPLACE(CAST(invoice.quantity - txn.quantity AS varchar), '(\d)(?=(\d{3})+\.)', '$1,') quantity_difference
-            , CONCAT('£', REGEXP_REPLACE(CAST(CAST((invoice.price + invoice.tax) AS decimal(10,2)) AS varchar), '(\d)(?=(\d{3})+\.)', '$1,')) billing_amount_with_tax
+            , REGEXP_REPLACE(CAST(invoice.quantity - txn.quantity AS VARCHAR), '(\d)(?=(\d{3})+\.)', '$1,') quantity_difference
+            , CONCAT('£', REGEXP_REPLACE(CAST(CAST((invoice.price + invoice.tax) AS decimal(10,2)) AS VARCHAR), '(\d)(?=(\d{3})+\.)', '$1,')) billing_amount_with_tax
             , (CASE
                 WHEN ((invoice.price = 0) AND (txn.price = 0)) THEN ${QueryMessageNoChargeForThisMonth}
                 WHEN ((invoice.price IS NULL) AND (invoice.quantity IS NULL)) THEN ${QueryMessageInvoiceDataMissing}

--- a/cloudformation/calculation-athena.yaml
+++ b/cloudformation/calculation-athena.yaml
@@ -301,6 +301,7 @@ Resources:
             , COALESCE(txn.contract_name, invoice.contract_name) contract_name
             , COALESCE(txn.year, invoice.year) year
             , COALESCE(txn.month, invoice.month) month
+            , invoice.unit_price billing_unit_price
             , CONCAT('£', REGEXP_REPLACE(CAST(CAST(invoice.price AS DECIMAL(10,2)) AS VARCHAR), '(\d)(?=(\d{3})+\.)', '$1,')) billing_price_formatted
             , CONCAT('£', REGEXP_REPLACE(CAST(CAST(txn.price AS DECIMAL(10,2)) AS VARCHAR), '(\d)(?=(\d{3})+\.)', '$1,')) transaction_price_formatted
             , CONCAT('£', REGEXP_REPLACE(CAST(CAST((invoice.price - txn.price) AS decimal(10,2)) AS varchar), '(\d)(?=(\d{3})+\.)', '$1,')) price_difference

--- a/cloudformation/invoice-athena.yaml
+++ b/cloudformation/invoice-athena.yaml
@@ -134,7 +134,7 @@ Resources:
             contract.name contract_name,
             event_name,
             sum(quantity) AS quantity,
-            unit_price,
+            btm.unit_price,
             sum(price) AS price,
             sum(tax) AS tax,
             year,
@@ -142,5 +142,5 @@ Resources:
           FROM btm_billing_standardised btm
           LEFT JOIN "btm_contracts_standardised" contract
                   ON (contract_id = contract.id)
-          GROUP BY btm.vendor_id,vendor_name,contract.id,contract.name,service_name,event_name,year,month
+          GROUP BY btm.vendor_id,btm.unit_price,vendor_name,contract.id,contract.name,service_name,event_name,year,month
         Workgroup: !Ref AthenaInvoiceWorkgroup

--- a/cloudformation/invoice-athena.yaml
+++ b/cloudformation/invoice-athena.yaml
@@ -134,6 +134,7 @@ Resources:
             contract.name contract_name,
             event_name,
             sum(quantity) AS quantity,
+            unit_price,
             sum(price) AS price,
             sum(tax) AS tax,
             year,

--- a/integration_tests/tests/dashboard-data-extraction-tests.ts
+++ b/integration_tests/tests/dashboard-data-extraction-tests.ts
@@ -87,6 +87,9 @@ describe("\n DashboardDataExtractFunction", () => {
     );
     expect(response[0].year).toEqual(year.toString());
     expect(response[0].month).toEqual(month.toString());
+    expect(response[0].billing_unit_price).toEqual(
+      "£" + standardisedInvoiceObject.unit_price.toFixed(4)
+    );
     expect(response[0].billing_price_formatted).toEqual(
       standardisedInvoiceObject.subtotal.toLocaleString("en-GB", {
         style: "currency",
@@ -118,6 +121,7 @@ interface BtmMonthlyExtract {
   contract_name: string;
   year: string;
   month: string;
+  billing_unit_price: string;
   billing_price_formatted: string;
   transaction_price_formatted: string;
   price_difference: string;

--- a/src/frontend/extract-helpers/get-invoice-banner.test.ts
+++ b/src/frontend/extract-helpers/get-invoice-banner.test.ts
@@ -11,6 +11,7 @@ describe("getInvoiceBanner", () => {
     contract_name: "FOOBAR1",
     year: "2005",
     month: "02",
+    billing_unit_price: "£0.0000",
     billing_price_formatted: "£0.00",
     transaction_price_formatted: "£27.50",
     price_difference: "£-27.50",

--- a/src/frontend/extract-helpers/get-reconciliation-rows.test.ts
+++ b/src/frontend/extract-helpers/get-reconciliation-rows.test.ts
@@ -10,6 +10,7 @@ describe("getReconciliationRows", () => {
     contract_name: "FOOBAR1",
     year: "2005",
     month: "02",
+    billing_unit_price: "£0.0000",
     billing_price_formatted: "£0.00",
     transaction_price_formatted: "£27.50",
     price_difference: "£-27.50",
@@ -36,10 +37,12 @@ describe("getReconciliationRows", () => {
           message: "Below Threshold",
           class: "govuk-tag--blue",
         },
+        billingUnitPrice: "£0.0000",
         billingQuantity: "2",
         transactionQuantity: "11",
         billingPrice: "£0.00",
         transactionPrice: "£27.50",
+        billingPriceInclVat: "",
       },
     ];
     // Act
@@ -52,6 +55,7 @@ describe("getReconciliationRows", () => {
     // Arrange
     const givenLineItems = [
       buildLineItem(lineItem, [
+        ["billing_unit_price", ""],
         ["billing_price_formatted", ""],
         ["price_difference", ""],
         ["billing_quantity", ""],
@@ -72,8 +76,10 @@ describe("getReconciliationRows", () => {
         },
         billingQuantity: "Invoice data missing",
         transactionQuantity: "11",
+        billingUnitPrice: "Invoice data missing",
         billingPrice: "Invoice data missing",
         transactionPrice: "£27.50",
+        billingPriceInclVat: "Invoice data missing",
       },
     ];
     // Act
@@ -86,6 +92,7 @@ describe("getReconciliationRows", () => {
     // Arrange
     const givenLineItems = [
       buildLineItem(lineItem, [
+        ["billing_unit_price", "£0.3200"],
         ["billing_price_formatted", "£96"],
         ["billing_quantity", "300"],
         ["transaction_price_formatted", ""],
@@ -108,8 +115,10 @@ describe("getReconciliationRows", () => {
         },
         billingQuantity: "300",
         transactionQuantity: "Events missing",
+        billingUnitPrice: "£0.3200",
         billingPrice: "£96",
         transactionPrice: "Events missing",
+        billingPriceInclVat: "£116.10",
       },
     ];
     // Act
@@ -122,6 +131,7 @@ describe("getReconciliationRows", () => {
     // Arrange
     const givenLineItems = [
       buildLineItem(lineItem, [
+        ["billing_unit_price", "£2.5000"],
         ["service_name", "Passport check"],
         ["billing_price_formatted", "£27.50"],
         ["billing_quantity", "11"],
@@ -133,6 +143,7 @@ describe("getReconciliationRows", () => {
         ["price_difference_percentage", "-1234567.05"], // MN for unexpected charge
       ]),
       buildLineItem(lineItem, [
+        ["billing_unit_price", "£9.0909"],
         ["service_name", "Standard Charge"],
         ["billing_price_formatted", "£100.00"],
         ["billing_quantity", "11"],
@@ -156,8 +167,10 @@ describe("getReconciliationRows", () => {
         },
         billingQuantity: "11",
         transactionQuantity: "2",
+        billingUnitPrice: "£2.5000",
         billingPrice: "£27.50",
         transactionPrice: "£0.00",
+        billingPriceInclVat: "£30.00",
       },
       {
         serviceName: "Standard Charge",
@@ -170,8 +183,10 @@ describe("getReconciliationRows", () => {
         },
         billingQuantity: "11",
         transactionQuantity: "11",
+        billingUnitPrice: "£9.0909",
         billingPrice: "£100.00",
         transactionPrice: "£100.00",
+        billingPriceInclVat: "£105.00",
       },
     ];
     // Act

--- a/src/frontend/extract-helpers/get-reconciliation-rows.ts
+++ b/src/frontend/extract-helpers/get-reconciliation-rows.ts
@@ -58,6 +58,30 @@ export const getReconciliationRows = (
   return rows;
 };
 
+export const getTotals = (
+  rows: ReconciliationRow[]
+): { billingPriceTotal: string; billingPriceInclVatTotal: string } => {
+  let billingPriceTotal = 0;
+  let billingPriceInclVatTotal = 0;
+
+  for (const row of rows) {
+    billingPriceTotal += Number(row.billingPrice.replace(/[^0-9.-]+/g, "")); // Converts currency string to float (Returns 0 if "Invoice data missing")
+    billingPriceInclVatTotal += Number(
+      row.billingPriceInclVat.replace(/[^0-9.-]+/g, "")
+    );
+  }
+  return {
+    billingPriceTotal: billingPriceTotal.toLocaleString("en-GB", {
+      style: "currency",
+      currency: "GBP",
+    }),
+    billingPriceInclVatTotal: billingPriceInclVatTotal.toLocaleString("en-GB", {
+      style: "currency",
+      currency: "GBP",
+    }),
+  };
+};
+
 const PERCENTAGE_DISCREPANCY = [
   percentageDiscrepancySpecialCase.MN_NO_CHARGE,
   percentageDiscrepancySpecialCase.MN_INVOICE_MISSING,

--- a/src/frontend/extract-helpers/get-reconciliation-rows.ts
+++ b/src/frontend/extract-helpers/get-reconciliation-rows.ts
@@ -9,7 +9,9 @@ export interface ReconciliationRow {
   status: { message: string; class: string };
   billingQuantity: string;
   transactionQuantity: string;
+  billingUnitPrice: string;
   billingPrice: string;
+  billingPriceInclVat: string;
   transactionPrice: string;
 }
 
@@ -34,8 +36,16 @@ export const getReconciliationRows = (
         item.transaction_quantity,
         item.price_difference_percentage
       ),
+      billingUnitPrice: getPrice(
+        item.billing_unit_price,
+        item.price_difference_percentage
+      ),
       billingPrice: getPrice(
         item.billing_price_formatted,
+        item.price_difference_percentage
+      ),
+      billingPriceInclVat: getPrice(
+        item.billing_amount_with_tax,
         item.price_difference_percentage
       ),
       transactionPrice: getPrice(

--- a/src/frontend/extract-helpers/types.ts
+++ b/src/frontend/extract-helpers/types.ts
@@ -6,6 +6,7 @@ export interface FullExtractLineItem {
   contract_name: string;
   year: string;
   month: string;
+  billing_unit_price: string;
   billing_price_formatted: string;
   transaction_price_formatted: string;
   price_difference: string;

--- a/src/frontend/handlers/__snapshots__/invoice.test.ts.snap
+++ b/src/frontend/handlers/__snapshots__/invoice.test.ts.snap
@@ -186,19 +186,21 @@ exports[`invoice handler Page displays Invoice above threshold banner text and t
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
         <th class="govuk-table__header" scope="col">Line Item</th>
-        <th class="govuk-table__header" scope="col">Quantity Discrepancy</th>
-        <th class="govuk-table__header" scope="col">Price Discrepancy</th>
-        <th class="govuk-table__header" scope="col">Percentage Discrepancy</th>
+        <th class="govuk-table__header govuk-table__header--numeric" scope="col">Quantity Discrepancy</th>
+        <th class="govuk-table__header govuk-table__header--numeric" scope="col">Price Discrepancy</th>
+        <th class="govuk-table__header govuk-table__header--numeric" scope="col">Percentage Discrepancy</th>
         <th class="govuk-table__header" scope="col">Status</th>
       </tr>
     </thead>
     
       <tbody class="govuk-table__body">
         <tr class="govuk-table__row">
-          <td class="govuk-table__cell">Passport check</td>
-          <td class="govuk-table__cell">6,592.00</td>
-          <td class="govuk-table__cell">26.37</td>
-          <td class="govuk-table__cell">9.8814%</td>
+          <th scope="row" class="govuk-table__header">
+            Passport check
+          </td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">6,592.00</td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">26.37</td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">9.8814%</td>
           <td class="govuk-table__cell">
             <strong class="govuk-tag govuk-tag--red">
   Above Threshold
@@ -210,10 +212,12 @@ exports[`invoice handler Page displays Invoice above threshold banner text and t
     
       <tbody class="govuk-table__body">
         <tr class="govuk-table__row">
-          <td class="govuk-table__cell">Passport check</td>
-          <td class="govuk-table__cell">-14</td>
-          <td class="govuk-table__cell">-4.76</td>
-          <td class="govuk-table__cell">-1.1235%</td>
+          <th scope="row" class="govuk-table__header">
+            Passport check
+          </td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">-14</td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">-4.76</td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">-1.1235%</td>
           <td class="govuk-table__cell">
             <strong class="govuk-tag govuk-tag--blue">
   Below Threshold
@@ -225,10 +229,12 @@ exports[`invoice handler Page displays Invoice above threshold banner text and t
     
       <tbody class="govuk-table__body">
         <tr class="govuk-table__row">
-          <td class="govuk-table__cell">Passport check</td>
-          <td class="govuk-table__cell">100.00</td>
-          <td class="govuk-table__cell">0.00</td>
-          <td class="govuk-table__cell">0%</td>
+          <th scope="row" class="govuk-table__header">
+            Passport check
+          </td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">100.00</td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">0.00</td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">0%</td>
           <td class="govuk-table__cell">
             <strong class="govuk-tag govuk-tag--green">
   Within Threshold
@@ -244,36 +250,42 @@ exports[`invoice handler Page displays Invoice above threshold banner text and t
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
         <th class="govuk-table__header" scope="col">Line Item</th>
-        <th class="govuk-table__header" scope="col">Invoiced Quantity</th>
-        <th class="govuk-table__header" scope="col">Measured Quantity</th>
-        <th class="govuk-table__header" scope="col">Quantity Discrepancy</th>
+        <th class="govuk-table__header govuk-table__header--numeric" scope="col">Invoiced Quantity</th>
+        <th class="govuk-table__header govuk-table__header--numeric" scope="col">Measured Quantity</th>
+        <th class="govuk-table__header govuk-table__header--numeric" scope="col">Quantity Discrepancy</th>
       </tr>
     </thead>
     
       <tbody class="govuk-table__body">
         <tr class="govuk-table__row">
-          <td class="govuk-table__cell">Passport check</td>
-          <td class="govuk-table__cell">73298</td>
-          <td class="govuk-table__cell">66706</td>
-          <td class="govuk-table__cell">6,592.00</td>
+          <th scope="row" class="govuk-table__header">
+            Passport check
+          </td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">73298</td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">66706</td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">6,592.00</td>
         </tr>
       </tbody>
     
       <tbody class="govuk-table__body">
         <tr class="govuk-table__row">
-          <td class="govuk-table__cell">Passport check</td>
-          <td class="govuk-table__cell">11324</td>
-          <td class="govuk-table__cell">11338</td>
-          <td class="govuk-table__cell">-14</td>
+          <th scope="row" class="govuk-table__header">
+            Passport check
+          </td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">11324</td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">11338</td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">-14</td>
         </tr>
       </tbody>
     
       <tbody class="govuk-table__body">
         <tr class="govuk-table__row">
-          <td class="govuk-table__cell">Passport check</td>
-          <td class="govuk-table__cell">100</td>
-          <td class="govuk-table__cell">100</td>
-          <td class="govuk-table__cell">100.00</td>
+          <th scope="row" class="govuk-table__header">
+            Passport check
+          </td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">100</td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">100</td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">100.00</td>
         </tr>
       </tbody>
     
@@ -283,36 +295,42 @@ exports[`invoice handler Page displays Invoice above threshold banner text and t
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
         <th class="govuk-table__header" scope="col">Line Item</th>
-        <th class="govuk-table__header" scope="col">Invoiced Price</th>
-        <th class="govuk-table__header" scope="col">Measured Price</th>
-        <th class="govuk-table__header" scope="col">Price Discrepancy</th>
+        <th class="govuk-table__header govuk-table__header--numeric" scope="col">Invoiced Price</th>
+        <th class="govuk-table__header govuk-table__header--numeric" scope="col">Measured Price</th>
+        <th class="govuk-table__header govuk-table__header--numeric" scope="col">Price Discrepancy</th>
       </tr>
     </thead>
     
       <tbody class="govuk-table__body">
         <tr class="govuk-table__row">
-          <td class="govuk-table__cell">Passport check</td>
-          <td class="govuk-table__cell">293.19</td>
-          <td class="govuk-table__cell">266.82</td>
-          <td class="govuk-table__cell">26.37</td>
+          <th scope="row" class="govuk-table__header">
+            Passport check
+          </td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">293.19</td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">266.82</td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">26.37</td>
         </tr>
       </tbody>
     
       <tbody class="govuk-table__body">
         <tr class="govuk-table__row">
-          <td class="govuk-table__cell">Passport check</td>
-          <td class="govuk-table__cell">3,850.16</td>
-          <td class="govuk-table__cell">3,854.92</td>
-          <td class="govuk-table__cell">-4.76</td>
+          <th scope="row" class="govuk-table__header">
+            Passport check
+          </td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">3,850.16</td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">3,854.92</td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">-4.76</td>
         </tr>
       </tbody>
     
       <tbody class="govuk-table__body">
         <tr class="govuk-table__row">
-          <td class="govuk-table__cell">Passport check</td>
-          <td class="govuk-table__cell">100</td>
-          <td class="govuk-table__cell">100</td>
-          <td class="govuk-table__cell">0.00</td>
+          <th scope="row" class="govuk-table__header">
+            Passport check
+          </td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">100</td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">100</td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">0.00</td>
         </tr>
       </tbody>
     
@@ -322,28 +340,83 @@ exports[`invoice handler Page displays Invoice above threshold banner text and t
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
         <th class="govuk-table__header" scope="col">Line Item</th>
-        <th class="govuk-table__header" scope="col">Quantity</th>
+        <th class="govuk-table__header govuk-table__header--numeric" scope="col">Quantity</th>
       </tr>
     </thead>
     
       <tbody class="govuk-table__body">
         <tr class="govuk-table__row">
-          <td class="govuk-table__cell">Passport check</td>
-          <td class="govuk-table__cell">66706</td>
+          <th scope="row" class="govuk-table__header">
+            Passport check
+          </td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">66706</td>
         </tr>
       </tbody>
     
       <tbody class="govuk-table__body">
         <tr class="govuk-table__row">
-          <td class="govuk-table__cell">Passport check</td>
-          <td class="govuk-table__cell">11338</td>
+          <th scope="row" class="govuk-table__header">
+            Passport check
+          </td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">11338</td>
         </tr>
       </tbody>
     
       <tbody class="govuk-table__body">
         <tr class="govuk-table__row">
-          <td class="govuk-table__cell">Passport check</td>
-          <td class="govuk-table__cell">100</td>
+          <th scope="row" class="govuk-table__header">
+            Passport check
+          </td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">100</td>
+        </tr>
+      </tbody>
+    
+  </table>
+  <table class="govuk-table">
+    <caption class="govuk-table__caption govuk-table__caption--m">Invoice</caption>
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th class="govuk-table__header" scope="col">Line Item</th>
+        <th class="govuk-table__header govuk-table__header--numeric" scope="col">Quantity</th>
+        <th class="govuk-table__header govuk-table__header--numeric" scope="col">Unit Price</th>
+        <th class="govuk-table__header govuk-table__header--numeric" scope="col">Total</th>
+        <th class="govuk-table__header govuk-table__header--numeric" scope="col">Total + VAT</th>
+      </tr>
+    </thead>
+    
+      <tbody class="govuk-table__body">
+        <tr class="govuk-table__row">
+          <th scope="row" class="govuk-table__header">
+            Passport check
+          </td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">73298</td>
+          <td class="govuk-table__cell govuk-table__cell--numeric"></td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">293.19</td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">351.83</td>
+        </tr>
+      </tbody>
+    
+      <tbody class="govuk-table__body">
+        <tr class="govuk-table__row">
+          <th scope="row" class="govuk-table__header">
+            Passport check
+          </td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">11324</td>
+          <td class="govuk-table__cell govuk-table__cell--numeric"></td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">3,850.16</td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">4,620.19</td>
+        </tr>
+      </tbody>
+    
+      <tbody class="govuk-table__body">
+        <tr class="govuk-table__row">
+          <th scope="row" class="govuk-table__header">
+            Passport check
+          </td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">100</td>
+          <td class="govuk-table__cell govuk-table__cell--numeric"></td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">100</td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">110</td>
         </tr>
       </tbody>
     

--- a/src/frontend/handlers/__snapshots__/invoice.test.ts.snap
+++ b/src/frontend/handlers/__snapshots__/invoice.test.ts.snap
@@ -245,6 +245,7 @@ exports[`invoice handler Page displays Invoice above threshold banner text and t
       </tbody>
     
   </table>
+  <div class="govuk-!-padding-bottom-7"></div>
   <table class="govuk-table">
     <caption class="govuk-table__caption govuk-table__caption--m">Quantity (events)</caption>
     <thead class="govuk-table__head">
@@ -335,6 +336,7 @@ exports[`invoice handler Page displays Invoice above threshold banner text and t
       </tbody>
     
   </table>
+  <div class="govuk-!-padding-bottom-7"></div>
   <table class="govuk-table">
     <caption class="govuk-table__caption govuk-table__caption--m">Measured (events)</caption>
     <thead class="govuk-table__head">
@@ -393,9 +395,7 @@ exports[`invoice handler Page displays Invoice above threshold banner text and t
           <td class="govuk-table__cell govuk-table__cell--numeric"></td>
           <td class="govuk-table__cell govuk-table__cell--numeric">293.19</td>
           <td class="govuk-table__cell govuk-table__cell--numeric">351.83</td>
-        </tr>
-      </tbody>
-    
+        
       <tbody class="govuk-table__body">
         <tr class="govuk-table__row">
           <th scope="row" class="govuk-table__header">
@@ -405,9 +405,7 @@ exports[`invoice handler Page displays Invoice above threshold banner text and t
           <td class="govuk-table__cell govuk-table__cell--numeric"></td>
           <td class="govuk-table__cell govuk-table__cell--numeric">3,850.16</td>
           <td class="govuk-table__cell govuk-table__cell--numeric">4,620.19</td>
-        </tr>
-      </tbody>
-    
+        
       <tbody class="govuk-table__body">
         <tr class="govuk-table__row">
           <th scope="row" class="govuk-table__header">
@@ -417,9 +415,16 @@ exports[`invoice handler Page displays Invoice above threshold banner text and t
           <td class="govuk-table__cell govuk-table__cell--numeric"></td>
           <td class="govuk-table__cell govuk-table__cell--numeric">100</td>
           <td class="govuk-table__cell govuk-table__cell--numeric">110</td>
-        </tr>
-      </tbody>
-    
+        
+      </tr>
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header">Total</th>
+        <td class="govuk-table__cell"></td>
+        <td class="govuk-table__cell"></td>
+        <td class="govuk-table__cell govuk-table__cell--numeric">£4,243.35</td>
+        <td class="govuk-table__cell govuk-table__cell--numeric">£5,082.02</td>
+      </tr>
+    </tbody>
   </table>
 
         </main>

--- a/src/frontend/handlers/invoice.ts
+++ b/src/frontend/handlers/invoice.ts
@@ -4,6 +4,7 @@ import {
   getInvoiceBanner,
   getLineItems,
   getReconciliationRows,
+  getTotals,
 } from "../extract-helpers";
 import { InvoiceParams, PageParamsGetter } from "../pages";
 
@@ -28,6 +29,8 @@ export const invoiceParamsGetter: PageParamsGetter<
 
   const reconciliationRows = getReconciliationRows(lineItems);
 
+  const invoiceTotals = getTotals(reconciliationRows);
+
   return {
     pageTitle: `${config.vendorName} ${
       MONTHS[Number(request.params.month) - 1]
@@ -40,5 +43,6 @@ export const invoiceParamsGetter: PageParamsGetter<
     bannerClass: invoiceBanner.bannerClass,
     invoiceStatus: invoiceBanner.status,
     reconciliationRows,
+    invoiceTotals,
   };
 };

--- a/src/frontend/views/invoice.njk
+++ b/src/frontend/views/invoice.njk
@@ -38,19 +38,21 @@
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
         <th class="govuk-table__header" scope="col">Line Item</th>
-        <th class="govuk-table__header" scope="col">Quantity Discrepancy</th>
-        <th class="govuk-table__header" scope="col">Price Discrepancy</th>
-        <th class="govuk-table__header" scope="col">Percentage Discrepancy</th>
+        <th class="govuk-table__header govuk-table__header--numeric" scope="col">Quantity Discrepancy</th>
+        <th class="govuk-table__header govuk-table__header--numeric" scope="col">Price Discrepancy</th>
+        <th class="govuk-table__header govuk-table__header--numeric" scope="col">Percentage Discrepancy</th>
         <th class="govuk-table__header" scope="col">Status</th>
       </tr>
     </thead>
     {% for row in reconciliationRows %}
       <tbody class="govuk-table__body">
         <tr class="govuk-table__row">
-          <td class="govuk-table__cell">{{ row.serviceName }}</td>
-          <td class="govuk-table__cell">{{ row.quantityDiscrepancy }}</td>
-          <td class="govuk-table__cell">{{ row.priceDiscrepancy }}</td>
-          <td class="govuk-table__cell">{{ row.percentageDiscrepancy }}</td>
+          <th scope="row" class="govuk-table__header">
+            {{ row.serviceName }}
+          </td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">{{ row.quantityDiscrepancy }}</td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">{{ row.priceDiscrepancy }}</td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">{{ row.percentageDiscrepancy }}</td>
           <td class="govuk-table__cell">
             {{ govukTag({
                         text: row.status.message,
@@ -66,18 +68,20 @@
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
         <th class="govuk-table__header" scope="col">Line Item</th>
-        <th class="govuk-table__header" scope="col">Invoiced Quantity</th>
-        <th class="govuk-table__header" scope="col">Measured Quantity</th>
-        <th class="govuk-table__header" scope="col">Quantity Discrepancy</th>
+        <th class="govuk-table__header govuk-table__header--numeric" scope="col">Invoiced Quantity</th>
+        <th class="govuk-table__header govuk-table__header--numeric" scope="col">Measured Quantity</th>
+        <th class="govuk-table__header govuk-table__header--numeric" scope="col">Quantity Discrepancy</th>
       </tr>
     </thead>
     {% for row in reconciliationRows %}
       <tbody class="govuk-table__body">
         <tr class="govuk-table__row">
-          <td class="govuk-table__cell">{{ row.serviceName }}</td>
-          <td class="govuk-table__cell">{{ row.billingQuantity }}</td>
-          <td class="govuk-table__cell">{{ row.transactionQuantity }}</td>
-          <td class="govuk-table__cell">{{ row.quantityDiscrepancy }}</td>
+          <th scope="row" class="govuk-table__header">
+            {{ row.serviceName }}
+          </td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">{{ row.billingQuantity }}</td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">{{ row.transactionQuantity }}</td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">{{ row.quantityDiscrepancy }}</td>
         </tr>
       </tbody>
     {% endfor %}
@@ -87,18 +91,20 @@
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
         <th class="govuk-table__header" scope="col">Line Item</th>
-        <th class="govuk-table__header" scope="col">Invoiced Price</th>
-        <th class="govuk-table__header" scope="col">Measured Price</th>
-        <th class="govuk-table__header" scope="col">Price Discrepancy</th>
+        <th class="govuk-table__header govuk-table__header--numeric" scope="col">Invoiced Price</th>
+        <th class="govuk-table__header govuk-table__header--numeric" scope="col">Measured Price</th>
+        <th class="govuk-table__header govuk-table__header--numeric" scope="col">Price Discrepancy</th>
       </tr>
     </thead>
     {% for row in reconciliationRows %}
       <tbody class="govuk-table__body">
         <tr class="govuk-table__row">
-          <td class="govuk-table__cell">{{ row.serviceName }}</td>
-          <td class="govuk-table__cell">{{ row.billingPrice }}</td>
-          <td class="govuk-table__cell">{{ row.transactionPrice }}</td>
-          <td class="govuk-table__cell">{{ row.priceDiscrepancy }}</td>
+          <th scope="row" class="govuk-table__header">
+            {{ row.serviceName }}
+          </td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">{{ row.billingPrice }}</td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">{{ row.transactionPrice }}</td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">{{ row.priceDiscrepancy }}</td>
         </tr>
       </tbody>
     {% endfor %}
@@ -108,14 +114,41 @@
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
         <th class="govuk-table__header" scope="col">Line Item</th>
-        <th class="govuk-table__header" scope="col">Quantity</th>
+        <th class="govuk-table__header govuk-table__header--numeric" scope="col">Quantity</th>
       </tr>
     </thead>
     {% for row in reconciliationRows %}
       <tbody class="govuk-table__body">
         <tr class="govuk-table__row">
-          <td class="govuk-table__cell">{{ row.serviceName }}</td>
-          <td class="govuk-table__cell">{{ row.transactionQuantity }}</td>
+          <th scope="row" class="govuk-table__header">
+            {{ row.serviceName }}
+          </td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">{{ row.transactionQuantity }}</td>
+        </tr>
+      </tbody>
+    {% endfor %}
+  </table>
+  <table class="govuk-table">
+    <caption class="govuk-table__caption govuk-table__caption--m">Invoice</caption>
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th class="govuk-table__header" scope="col">Line Item</th>
+        <th class="govuk-table__header govuk-table__header--numeric" scope="col">Quantity</th>
+        <th class="govuk-table__header govuk-table__header--numeric" scope="col">Unit Price</th>
+        <th class="govuk-table__header govuk-table__header--numeric" scope="col">Total</th>
+        <th class="govuk-table__header govuk-table__header--numeric" scope="col">Total + VAT</th>
+      </tr>
+    </thead>
+    {% for row in reconciliationRows %}
+      <tbody class="govuk-table__body">
+        <tr class="govuk-table__row">
+          <th scope="row" class="govuk-table__header">
+            {{ row.serviceName }}
+          </td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">{{ row.billingQuantity }}</td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">{{ row.billingUnitPrice }}</td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">{{ row.billingPrice }}</td>
+          <td class="govuk-table__cell govuk-table__cell--numeric">{{ row.billingPriceInclVat }}</td>
         </tr>
       </tbody>
     {% endfor %}

--- a/src/frontend/views/invoice.njk
+++ b/src/frontend/views/invoice.njk
@@ -63,6 +63,7 @@
       </tbody>
     {% endfor %}
   </table>
+  <div class="govuk-!-padding-bottom-7"></div>
   <table class="govuk-table">
     <caption class="govuk-table__caption govuk-table__caption--m">Quantity (events)</caption>
     <thead class="govuk-table__head">
@@ -109,6 +110,7 @@
       </tbody>
     {% endfor %}
   </table>
+  <div class="govuk-!-padding-bottom-7"></div>
   <table class="govuk-table">
     <caption class="govuk-table__caption govuk-table__caption--m">Measured (events)</caption>
     <thead class="govuk-table__head">
@@ -149,8 +151,15 @@
           <td class="govuk-table__cell govuk-table__cell--numeric">{{ row.billingUnitPrice }}</td>
           <td class="govuk-table__cell govuk-table__cell--numeric">{{ row.billingPrice }}</td>
           <td class="govuk-table__cell govuk-table__cell--numeric">{{ row.billingPriceInclVat }}</td>
-        </tr>
-      </tbody>
-    {% endfor %}
+        {% endfor %}
+      </tr>
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header">Total</th>
+        <td class="govuk-table__cell"></td>
+        <td class="govuk-table__cell"></td>
+        <td class="govuk-table__cell govuk-table__cell--numeric">{{ invoiceTotals.billingPriceTotal }}</td>
+        <td class="govuk-table__cell govuk-table__cell--numeric">{{ invoiceTotals.billingPriceInclVatTotal }}</td>
+      </tr>
+    </tbody>
   </table>
 {% endblock content %}


### PR DESCRIPTION
### UI for the Invoice Table as per the moqup [here](https://app.moqups.com/DpSOLhFxFMD222IpkWjpPj8BHy6BhoyE/edit/page/a179ad680).

### Example:


> One row:
> ![image](https://github.com/alphagov/di-billing-transaction-monitoring/assets/116570124/5ae35e90-85f2-4d4f-bce0-770c1b12fadf)


> One row with invoice data missing:
> ![image](https://github.com/alphagov/di-billing-transaction-monitoring/assets/116570124/c2c3159b-f083-41d8-8bd6-de9773cafd57)


> Two rows, where one has invoice data missing:
> ![image](https://github.com/alphagov/di-billing-transaction-monitoring/assets/116570124/ac7fb7be-2bc5-4dc6-b467-aa579822cda4)


> Multiple rows:
> ![image](https://github.com/alphagov/di-billing-transaction-monitoring/assets/116570124/3408ad78-07ed-402f-a2ba-887766f304a9)
