### PR TITLE
BTM-499: centralise references to eu-west-2

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -3,6 +3,7 @@ extends:
   - prettier
 ignorePatterns:
   - dist
+  - reports
   - ui-tests/testData/testData.json
 plugins:
   - 'jest-formatting'

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
   },
   "scripts": {
     "husky:install": "husky install",
-    "test": "jest --maxWorkers=4 --silent",
+    "test": "jest --maxWorkers=1 --silent",
     "test:ephemeralEnvs": "jest --config jest.integration.config.ts --testPathIgnorePatterns email-storage-tests e2e-tests --maxWorkers=4 $JEST_ARGS; RET=$? ; npm run test:cleanup:reports ; exit $RET",
     "test:integration": "jest --config jest.integration.config.ts --maxWorkers=4 $JEST_ARGS; RET=$? ; npm run test:cleanup:reports ; exit $RET",
     "test:end2end": "jest --config jest.e2e.config.ts",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
   },
   "scripts": {
     "husky:install": "husky install",
-    "test": "jest --maxWorkers=4 --silent",
+    "test": "jest --maxWorkers=2 --silent",
     "test:ephemeralEnvs": "jest --config jest.integration.config.ts --testPathIgnorePatterns email-storage-tests e2e-tests --maxWorkers=4 $JEST_ARGS; RET=$? ; npm run test:cleanup:reports ; exit $RET",
     "test:integration": "jest --config jest.integration.config.ts --maxWorkers=4 $JEST_ARGS; RET=$? ; npm run test:cleanup:reports ; exit $RET",
     "test:end2end": "jest --config jest.e2e.config.ts",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
   },
   "scripts": {
     "husky:install": "husky install",
-    "test": "jest --maxWorkers=1 --silent",
+    "test": "jest --maxWorkers=2 --silent",
     "test:ephemeralEnvs": "jest --config jest.integration.config.ts --testPathIgnorePatterns email-storage-tests e2e-tests --maxWorkers=4 $JEST_ARGS; RET=$? ; npm run test:cleanup:reports ; exit $RET",
     "test:integration": "jest --config jest.integration.config.ts --maxWorkers=4 $JEST_ARGS; RET=$? ; npm run test:cleanup:reports ; exit $RET",
     "test:end2end": "jest --config jest.e2e.config.ts",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
   },
   "scripts": {
     "husky:install": "husky install",
-    "test": "jest --maxWorkers=1 --silent",
+    "test": "jest --maxWorkers=4 --silent",
     "test:ephemeralEnvs": "jest --config jest.integration.config.ts --testPathIgnorePatterns email-storage-tests e2e-tests --maxWorkers=4 $JEST_ARGS; RET=$? ; npm run test:cleanup:reports ; exit $RET",
     "test:integration": "jest --config jest.integration.config.ts --maxWorkers=4 $JEST_ARGS; RET=$? ; npm run test:cleanup:reports ; exit $RET",
     "test:end2end": "jest --config jest.e2e.config.ts",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
   },
   "scripts": {
     "husky:install": "husky install",
-    "test": "jest --maxWorkers=2 --silent",
+    "test": "jest --maxWorkers=4 --silent",
     "test:ephemeralEnvs": "jest --config jest.integration.config.ts --testPathIgnorePatterns email-storage-tests e2e-tests --maxWorkers=4 $JEST_ARGS; RET=$? ; npm run test:cleanup:reports ; exit $RET",
     "test:integration": "jest --config jest.integration.config.ts --maxWorkers=4 $JEST_ARGS; RET=$? ; npm run test:cleanup:reports ; exit $RET",
     "test:end2end": "jest --config jest.e2e.config.ts",

--- a/src/handlers/custom-athena-view-resource/handler.test.ts
+++ b/src/handlers/custom-athena-view-resource/handler.test.ts
@@ -4,6 +4,7 @@ import { sendCustomResourceResult } from "../../shared/utils";
 import { getAthenaViewResourceData } from "./get-athena-view-resource-data";
 import { handler } from "./handler";
 import { AthenaQueryExecutor } from "../../shared/utils/athena";
+import { AWS_REGION } from "../../shared/constants";
 
 jest.mock("aws-sdk");
 const MockedAthenaClass = Athena as jest.MockedClass<typeof Athena>;
@@ -137,7 +138,7 @@ describe("Custom Athena view resource handler", () => {
     await handler(givenEvent, givenContext);
 
     expect(MockedAthenaClass).toHaveBeenCalledTimes(1);
-    expect(MockedAthenaClass).toHaveBeenCalledWith({ region: "eu-west-2" });
+    expect(MockedAthenaClass).toHaveBeenCalledWith({ region: AWS_REGION });
     expect(mockedAthenaStartQueryExecution).toHaveBeenCalledTimes(1);
     expect(mockedAthenaStartQueryExecution).toHaveBeenCalledWith({
       QueryExecutionContext: {

--- a/src/handlers/custom-athena-view-resource/handler.ts
+++ b/src/handlers/custom-athena-view-resource/handler.ts
@@ -3,6 +3,7 @@ import { Athena } from "aws-sdk";
 import { logger, sendCustomResourceResult } from "../../shared/utils";
 import { getAthenaViewResourceData } from "./get-athena-view-resource-data";
 import { AthenaQueryExecutor } from "../../shared/utils/athena";
+import { AWS_REGION } from "../../shared/constants";
 
 export const handler = async (
   event: CloudFormationCustomResourceEvent,
@@ -12,7 +13,7 @@ export const handler = async (
     const { database, name, query, workgroup } =
       getAthenaViewResourceData(event);
 
-    const athena = new Athena({ region: "eu-west-2" });
+    const athena = new Athena({ region: AWS_REGION });
 
     const { QueryExecutionId: queryExecutionId } = await athena
       .startQueryExecution({

--- a/src/handlers/dashboard-extract/fetch-view-data.ts
+++ b/src/handlers/dashboard-extract/fetch-view-data.ts
@@ -3,8 +3,9 @@ import { Athena } from "aws-sdk/clients/all";
 import { ResultSet } from "@aws-sdk/client-athena";
 import { Env } from "./types";
 import { AthenaQueryExecutor } from "../../shared/utils/athena";
+import { AWS_REGION } from "../../shared/constants";
 
-const athena = new Athena({ region: "eu-west-2" });
+const athena = new Athena({ region: AWS_REGION });
 
 const QUERY_WAIT = 30 * 1000; // Thirty seconds
 

--- a/src/handlers/int-test-support/clients.ts
+++ b/src/handlers/int-test-support/clients.ts
@@ -2,30 +2,26 @@ import { AthenaClient } from "@aws-sdk/client-athena";
 import { CloudWatchLogsClient } from "@aws-sdk/client-cloudwatch-logs";
 import { LambdaClient } from "@aws-sdk/client-lambda";
 import { S3Client } from "@aws-sdk/client-s3";
-import { SESClient } from "@aws-sdk/client-ses";
 import AWS from "aws-sdk";
-
-export const region = "eu-west-2";
+import { AWS_REGION } from "../../shared/constants";
 
 export const athenaClient = new AthenaClient({
-  region,
+  region: AWS_REGION,
   endpoint: process.env.LOCAL_ENDPOINT,
 });
 
 export const cloudWatchLogsClient = new CloudWatchLogsClient({
-  region,
+  region: AWS_REGION,
   endpoint: process.env.LOCAL_ENDPOINT,
 });
 
 export const s3Client = new S3Client({
-  region,
+  region: AWS_REGION,
   endpoint: process.env.S3_LOCALENDPOINT,
 });
 
-export const lambdaClient = new LambdaClient({ region });
-
-export const sesClient = new SESClient({ region: "eu-west-1" });
+export const lambdaClient = new LambdaClient({ region: AWS_REGION });
 
 export const kms = new AWS.KMS({
-  region: "eu-west-2",
+  region: AWS_REGION,
 });

--- a/src/handlers/int-test-support/helpers/mock-data/csv/objectsToCsv.test.ts
+++ b/src/handlers/int-test-support/helpers/mock-data/csv/objectsToCsv.test.ts
@@ -20,6 +20,7 @@ describe("objectsToCSV", () => {
       expect(csv).toEqual(expectedCsv);
     });
   });
+
   describe("Given an array of self-similar objects with string values", () => {
     it("Returns a CSV containing one row for each object", () => {
       const objects = [
@@ -39,6 +40,7 @@ describe("objectsToCSV", () => {
       expect(csv).toEqual(expectedCsv);
     });
   });
+
   describe("Given a list of keys to filter", () => {
     it("removes those keys from the output", () => {
       const objects = [
@@ -58,6 +60,7 @@ describe("objectsToCSV", () => {
       expect(csv).toEqual(expectedCsv);
     });
   });
+
   describe("Given a dictionary of keys to rename", () => {
     it("renames those keys in the output", () => {
       const objects = [

--- a/src/handlers/int-test-support/helpers/query-athena-helper.test.ts
+++ b/src/handlers/int-test-support/helpers/query-athena-helper.test.ts
@@ -21,6 +21,7 @@ describe("queryAthena", () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
+
   it("should execute a query and return the results", async () => {
     const queryId = "test123";
     mockedStartQueryExecutionCommand.mockResolvedValue(queryId);

--- a/src/handlers/int-test-support/helpers/secretsManagerHelper.ts
+++ b/src/handlers/int-test-support/helpers/secretsManagerHelper.ts
@@ -1,8 +1,9 @@
 import AWS from "aws-sdk";
+import { AWS_REGION } from "../../../shared/constants";
 
 type GetSecretOptions = { id: string };
 
-const secretsManager = new AWS.SecretsManager({ region: "eu-west-2" });
+const secretsManager = new AWS.SecretsManager({ region: AWS_REGION });
 
 const cache: Partial<Record<string, string>> = {};
 

--- a/src/handlers/int-test-support/helpers/sesHelper.ts
+++ b/src/handlers/int-test-support/helpers/sesHelper.ts
@@ -3,6 +3,7 @@ import { IntTestHelpers } from "../types";
 import { runViaLambda } from "./envHelper";
 import { sendLambdaCommand } from "./lambdaHelper";
 import { getSecret } from "./secretsManagerHelper";
+import { AWS_REGION } from "../../../shared/constants";
 
 export type EmailParams = {
   SourceAddress: string;
@@ -32,7 +33,7 @@ export const sendEmail = async (params: EmailParams): Promise<string> => {
     ]);
 
     const transporter = nodemailer.createTransport({
-      host: "email-smtp.eu-west-2.amazonaws.com",
+      host: `email-smtp.${AWS_REGION}.amazonaws.com`,
       port: 465,
       secure: true,
       auth: { user, pass },

--- a/src/handlers/pdf-extract/handler.ts
+++ b/src/handlers/pdf-extract/handler.ts
@@ -2,6 +2,7 @@ import * as AWS from "aws-sdk";
 import { SQSEvent } from "aws-lambda";
 import { Response } from "../../shared/types";
 import { getS3EventRecordsFromSqs, logger } from "../../shared/utils";
+import { AWS_REGION } from "../../shared/constants";
 
 export const handler = async (event: SQSEvent): Promise<Response> => {
   // Set Up
@@ -15,7 +16,7 @@ export const handler = async (event: SQSEvent): Promise<Response> => {
     throw new Error("SNS Topic not set.");
   }
 
-  const textract = new AWS.Textract({ region: "eu-west-2" });
+  const textract = new AWS.Textract({ region: AWS_REGION });
   const response: Response = {
     batchItemFailures: [],
   };

--- a/src/handlers/process-email/business-logic.test.ts
+++ b/src/handlers/process-email/business-logic.test.ts
@@ -4,6 +4,7 @@ import { simpleParser } from "mailparser";
 
 jest.mock("mailparser");
 const mockedSimpleParser = simpleParser as jest.Mock;
+
 describe("process-email business logic", () => {
   let validIncomingEventBody: string;
   let givenInfoLogger: jest.Mock;
@@ -32,6 +33,7 @@ describe("process-email business logic", () => {
       businessLogic(validIncomingEventBody, mockContext, invalidMockMeta)
     ).rejects.toThrowError("Missing bucketName and/or key");
   });
+
   test("should return empty array with event record that has no vendor ID folder", async () => {
     const mockMeta = {
       bucketName: "given bucket name",

--- a/src/handlers/transaction-csv-to-json-event/convert/csv-to-json.test.ts
+++ b/src/handlers/transaction-csv-to-json-event/convert/csv-to-json.test.ts
@@ -26,6 +26,7 @@ describe("csvToJson", () => {
       const result = await csvToJson(givenCsv, givenRenamingConfig);
       expect(result).toEqual(expectedResult);
     });
+
     describe("given an invalid csv", () => {
       it("throws an error", async () => {
         const givenInvalidCsv = `an invalid csv`;

--- a/src/handlers/transaction-csv-to-json-event/convert/perform-transformations.test.ts
+++ b/src/handlers/transaction-csv-to-json-event/convert/perform-transformations.test.ts
@@ -93,6 +93,7 @@ describe("transform", () => {
         },
       ]);
     });
+
     it("performs the transformations to timestampOfManufacture when given dateOfManufacture as milliseconds", () => {
       type AugmentedHoover = RawHoover & {
         eyelashLength: number;
@@ -169,6 +170,7 @@ describe("transform", () => {
         },
       ]);
     });
+
     it("performs the transformations of timestampOfManufacture from string to number when given timestampOfManufacture as seconds", () => {
       type AugmentedHoover = RawHoover & {
         eyelashLength: number;

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -21,7 +21,4 @@ export const VALID_TEXTRACT_STATUS_MESSAGES = new Set<ValidTextractJobStatus>([
   "SUCCEEDED",
 ]);
 
-export const VENDOR_INVOICE_STANDARDISATION_CONFIG_PATH =
-  "vendor-invoice-standardisation.json";
-
-export const VENDOR_SERVICE_CONFIG_PATH = "vendor_services/vendor-services.csv";
+export const AWS_REGION = "eu-west-2";

--- a/src/shared/utils/kms/client.ts
+++ b/src/shared/utils/kms/client.ts
@@ -1,6 +1,7 @@
 import AWS from "aws-sdk";
+import { AWS_REGION } from "../../constants";
 
 export const kms = new AWS.KMS({
-  region: "eu-west-2",
+  region: AWS_REGION,
   endpoint: process.env.LOCAL_ENDPOINT,
 });

--- a/src/shared/utils/s3.ts
+++ b/src/shared/utils/s3.ts
@@ -13,6 +13,7 @@ import type { Command, SmithyConfiguration } from "@aws-sdk/smithy-client";
 import { S3Event, S3EventRecord, SQSRecord } from "aws-lambda";
 import { logger } from "./logger";
 import { decryptKms } from "./kms";
+import { AWS_REGION } from "../constants";
 
 type EncryptedS3ObjectMetadata = {
   "x-amz-cek-alg": string;
@@ -23,7 +24,7 @@ type EncryptedS3ObjectMetadata = {
 };
 
 const s3 = new S3Client({
-  region: "eu-west-2",
+  region: AWS_REGION,
   endpoint: process.env.LOCAL_ENDPOINT,
 });
 

--- a/src/shared/utils/sqs.ts
+++ b/src/shared/utils/sqs.ts
@@ -1,8 +1,9 @@
 import { SQSClient, SendMessageCommand } from "@aws-sdk/client-sqs";
 import { logger } from "./logger";
+import { AWS_REGION } from "../constants";
 
 const sqs = new SQSClient({
-  region: "eu-west-2",
+  region: AWS_REGION,
   endpoint: process.env.LOCAL_ENDPOINT,
 });
 

--- a/src/tools/delete-bucket.ts
+++ b/src/tools/delete-bucket.ts
@@ -8,6 +8,7 @@ import {
   ListObjectVersionsCommand,
   S3Client,
 } from "@aws-sdk/client-s3";
+import { AWS_REGION } from "../shared/constants";
 
 interface AWSError {
   error: any;
@@ -99,7 +100,7 @@ const deleteBucket = async (bucket: string): Promise<string | null> => {
   return await deleteEmptyBucket(bucket);
 };
 
-const awsConfig = { region: "eu-west-2" };
+const awsConfig = { region: AWS_REGION };
 const s3Client = new S3Client(awsConfig);
 
 const bucketName = process.env.BUCKET;

--- a/src/tools/teardown-cf-stack.ts
+++ b/src/tools/teardown-cf-stack.ts
@@ -18,6 +18,7 @@ import {
   StackResourceSummary,
 } from "@aws-sdk/client-cloudformation";
 import { AthenaClient, DeleteWorkGroupCommand } from "@aws-sdk/client-athena";
+import { AWS_REGION } from "../shared/constants";
 
 interface AWSError {
   error: any;
@@ -240,7 +241,7 @@ const tryToDelete = async (
   }
 };
 
-const awsConfig = { region: "eu-west-2" };
+const awsConfig = { region: AWS_REGION };
 const s3Client = new S3Client(awsConfig);
 const cfClient = new CloudFormationClient(awsConfig);
 const athenaClient = new AthenaClient(awsConfig);


### PR DESCRIPTION
CF files now use AWS::Region where possible.

A new global has also been defined for .ts files to use.