### PR TITLE
BTM-709: fix invoice no-charge banner

### DIFF
--- a/src/frontend/extract-helpers/get-invoice-banner.test.ts
+++ b/src/frontend/extract-helpers/get-invoice-banner.test.ts
@@ -207,4 +207,18 @@ describe("getInvoiceBanner", () => {
       status: "Invoice within threshold",
     });
   });
+
+  test("should return the expected invoice status and the payable banner class when there is only one line item and it has no charge", () => {
+    // Arrange
+    const givenLineItems = [
+      buildLineItem(lineItem, [["price_difference_percentage", "-1234567.01"]]),
+    ];
+    // Act
+    const result = getInvoiceBanner(givenLineItems);
+    // Assert
+    expect(result).toEqual({
+      bannerClass: "payable",
+      status: "Invoice within threshold",
+    });
+  });
 });

--- a/src/frontend/extract-helpers/get-invoice-banner.ts
+++ b/src/frontend/extract-helpers/get-invoice-banner.ts
@@ -61,7 +61,12 @@ export const getInvoiceBanner = (
     status = InvoiceBannerStatus.invoiceAboveThreshold;
     bannerClass = InvoiceBannerClass.error;
   } else if (
-    lineItems.find((lineItem) => +lineItem.price_difference_percentage <= -1)
+    lineItems.find(
+      ({ price_difference_percentage }) =>
+        +price_difference_percentage <= -1 &&
+        price_difference_percentage !==
+          percentageDiscrepancySpecialCase.MN_NO_CHARGE.magicNumber
+    )
   ) {
     status = InvoiceBannerStatus.invoiceBelowThreshold;
     bannerClass = InvoiceBannerClass.notice;


### PR DESCRIPTION
Makes banner match line item when there is only one and it has no charge