### PR TITLE
Fix deployment teardown

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "checkov": "checkov --quiet -f template.yaml --framework cloudformation --external-checks-git git@github.com:alphagov/di-devplatform-checkov-hook.git//src/gds_digitalidentity_checkovhook/custom_policies",
     "sam:build": "npm run build && npm run build:template && npm run checkov && sam build",
     "sam:deploy": "sam deploy --disable-rollback --no-fail-on-empty-changeset --stack-name di-btm-${ENV_NAME} --parameter-overrides Environment=dev PrivateConfigStack=${CONFIG_NAME:-none} TestRoleArn=${TEST_ROLE_ARN:-none} EnableAlerting=${ENABLE_ALERTING:-false} --s3-prefix ${ENV_NAME}",
-    "sam:teardown": "ts-node --esm src/tools/teardown-cf-stack.ts",
+    "sam:teardown": "ts-node --esm --experimental-specifier-resolution=node src/tools/teardown-cf-stack.ts",
     "typecheck": "tsc --noEmit",
     "dev:ts": "nodemon --esm --experimental-specifier-resolution=node src/frontend/server.ts",
     "dev:css": "sass src/frontend/styles/all.scss src/frontend/styles/all.css -w",


### PR DESCRIPTION
After the environment-variable refactor, an `import` bug prevented pull-request stack removal