### PR TITLE
BTM-710: fix unexpected-charge label

### DIFF
--- a/src/frontend/extract-helpers/get-reconciliation-rows.test.ts
+++ b/src/frontend/extract-helpers/get-reconciliation-rows.test.ts
@@ -162,8 +162,8 @@ describe("getReconciliationRows", () => {
         priceDiscrepancy: "£27.50",
         percentageDiscrepancy: "Unexpected invoice charge",
         status: {
-          message: "Above Threshold",
-          class: "govuk-tag--red",
+          message: "Error",
+          class: "govuk-tag--grey",
         },
         billingQuantity: "11",
         transactionQuantity: "2",
@@ -273,8 +273,8 @@ describe("getReconciliationRows", () => {
           priceDiscrepancy: "£27.50",
           percentageDiscrepancy: "Unexpected invoice charge",
           status: {
-            message: "Above Threshold",
-            class: "govuk-tag--red",
+            message: "Error",
+            class: "govuk-tag--grey",
           },
           billingQuantity: "11",
           transactionQuantity: "2",

--- a/src/frontend/utils/percentage-discrepancy-special-case.ts
+++ b/src/frontend/utils/percentage-discrepancy-special-case.ts
@@ -43,6 +43,6 @@ export const percentageDiscrepancySpecialCase = {
   MN_UNEXPECTED_CHARGE: {
     magicNumber: "-1234567.05",
     bannerText: InvoiceBannerStatus.unexpectedInvoiceCharge,
-    statusLabel: statusLabels.STATUS_LABEL_ABOVE_THRESHOLD,
+    statusLabel: statusLabels.STATUS_LABEL_ERROR,
   },
 };


### PR DESCRIPTION
On invoice page, for reconciliation-table rows with unexpected charges, matches their status badges' style with header banner