### PR TITLE
BTM 722  overview table tests

### DIFF
--- a/ui-tests/pageobjects/homepage.ts
+++ b/ui-tests/pageobjects/homepage.ts
@@ -17,8 +17,24 @@ class HomePage extends Page {
     return $('a[href$="/contracts"]');
   }
 
+  public get viewInvoiceLink(): Promise<WebdriverIO.Element> {
+    return $("=View Invoice");
+  }
+
+  public get overviewTableFirstContractLink(): Promise<WebdriverIO.Element> {
+    return $('a[href*="/contracts/1/invoices"]');
+  }
+
   public async clickOnContractsPageLink(): Promise<void> {
     await (await this.contractsLink).click();
+  }
+
+  public async clickOnViewInvoiceLink(): Promise<void> {
+    await (await this.viewInvoiceLink).click();
+  }
+
+  public async clickOnFirstContractInTable(): Promise<void> {
+    await (await this.overviewTableFirstContractLink).click();
   }
 
   public async getTableData(

--- a/ui-tests/pageobjects/homepage.ts
+++ b/ui-tests/pageobjects/homepage.ts
@@ -36,32 +36,6 @@ class HomePage extends Page {
   public async clickOnFirstContractInTable(): Promise<void> {
     await (await this.overviewTableFirstContractLink).click();
   }
-
-  public async getTableData(
-    tableElement: WebdriverIO.Element
-  ): Promise<Array<{ [key: string]: string }>> {
-    const tableData: Array<{ [key: string]: string }> = [];
-
-    const rows = await tableElement.$$("tbody tr");
-    const headerRow = await tableElement.$("thead tr");
-    const headerColumns = await headerRow.$$("th");
-
-    const columnHeaders = await Promise.all(
-      headerColumns.map(async (headerColumn) => await headerColumn.getText())
-    );
-
-    for (const row of rows) {
-      const columns = await row.$$("th,td");
-      const rowData: { [key: string]: string } = {};
-
-      for (const [index, header] of columnHeaders.entries()) {
-        rowData[header] = await columns[index].getText();
-      }
-
-      tableData.push(rowData);
-    }
-    return tableData;
-  }
 }
 
 export default new HomePage();

--- a/ui-tests/pageobjects/homepage.ts
+++ b/ui-tests/pageobjects/homepage.ts
@@ -9,12 +9,42 @@ class HomePage extends Page {
     return $("p.govuk-body");
   }
 
+  public get overViewTable(): Promise<WebdriverIO.Element> {
+    return $("caption*=Overview").parentElement();
+  }
+
   public get contractsLink(): Promise<WebdriverIO.Element> {
     return $('a[href$="/contracts"]');
   }
 
   public async clickOnContractsPageLink(): Promise<void> {
     await (await this.contractsLink).click();
+  }
+
+  public async getTableData(
+    tableElement: WebdriverIO.Element
+  ): Promise<Array<{ [key: string]: string }>> {
+    const tableData: Array<{ [key: string]: string }> = [];
+
+    const rows = await tableElement.$$("tbody tr");
+    const headerRow = await tableElement.$("thead tr");
+    const headerColumns = await headerRow.$$("th");
+
+    const columnHeaders = await Promise.all(
+      headerColumns.map(async (headerColumn) => await headerColumn.getText())
+    );
+
+    for (const row of rows) {
+      const columns = await row.$$("th,td");
+      const rowData: { [key: string]: string } = {};
+
+      for (const [index, header] of columnHeaders.entries()) {
+        rowData[header] = await columns[index].getText();
+      }
+
+      tableData.push(rowData);
+    }
+    return tableData;
   }
 }
 

--- a/ui-tests/pageobjects/invoicePage.ts
+++ b/ui-tests/pageobjects/invoicePage.ts
@@ -36,6 +36,10 @@ class InvoicePage extends Page {
     return $("caption*=Invoice").parentElement();
   }
 
+  public get invoiceBreadcrumbsLink(): Promise<WebdriverIO.Element> {
+    return $('a[href$="/invoices"]');
+  }
+
   public async getStatusBannerTitle(): Promise<string> {
     await (await this.statusBannerTitle).isDisplayed();
     return await (await this.statusBannerTitle).getText();
@@ -48,30 +52,8 @@ class InvoicePage extends Page {
     return color.parsed.hex ?? "";
   }
 
-  public async getTableData(
-    tableElement: WebdriverIO.Element
-  ): Promise<Array<{ [key: string]: string }>> {
-    const tableData: Array<{ [key: string]: string }> = [];
-
-    const rows = await tableElement.$$("tbody tr");
-    const headerRow = await tableElement.$("thead tr");
-    const headerColumns = await headerRow.$$("th");
-
-    const columnHeaders = await Promise.all(
-      headerColumns.map(async (headerColumn) => await headerColumn.getText())
-    );
-
-    for (const row of rows) {
-      const columns = await row.$$("th,td");
-      const rowData: { [key: string]: string } = {};
-
-      for (const [index, header] of columnHeaders.entries()) {
-        rowData[header] = await columns[index].getText();
-      }
-
-      tableData.push(rowData);
-    }
-    return tableData;
+  public async clickOnInvoiceBreadcrumbsLink(): Promise<void> {
+    await (await this.invoiceBreadcrumbsLink).click();
   }
 }
 

--- a/ui-tests/pageobjects/invoicesListPage.ts
+++ b/ui-tests/pageobjects/invoicesListPage.ts
@@ -1,8 +1,12 @@
 import Page from "./page";
 
-class VendorPage extends Page {
+class InvoicesListPage extends Page {
   public get invoicesList(): Promise<WebdriverIO.Element[]> {
     return $$("ul.govuk-list li");
+  }
+
+  public get contractsBreadcrumbsLink(): Promise<WebdriverIO.Element> {
+    return $('a[href$="/contracts"]');
   }
 
   public async getInvoiceCount(): Promise<number> {
@@ -11,13 +15,9 @@ class VendorPage extends Page {
     return length;
   }
 
-  public get invoiceLinkByIndex(): Promise<WebdriverIO.Element> {
-    return $('a[href$="/contracts/1/invoices/2023-01"]');
-  }
-
-  public async clickInvoice(): Promise<void> {
-    await (await this.invoiceLinkByIndex).click();
+  public async clickOnContractsBreadcrumbsLink(): Promise<void> {
+    await (await this.contractsBreadcrumbsLink).click();
   }
 }
 
-export default new VendorPage();
+export default new InvoicesListPage();

--- a/ui-tests/pageobjects/page.ts
+++ b/ui-tests/pageobjects/page.ts
@@ -11,6 +11,10 @@ export default class Page {
     return $(".govuk-heading-l");
   }
 
+  public get breadcrumbs(): Promise<WebdriverIO.ElementArray> {
+    return $$("li.govuk-breadcrumbs__list-item");
+  }
+
   public async isPageHeadingDisplayed(): Promise<boolean> {
     return await (await this.pageHeading).isDisplayed();
   }
@@ -25,5 +29,42 @@ export default class Page {
 
   public async getPageSubHeadingText(): Promise<string> {
     return await (await this.pageSubHeading).getText();
+  }
+
+  public async getTableData(
+    tableElement: WebdriverIO.Element
+  ): Promise<Array<{ [key: string]: string }>> {
+    const tableData: Array<{ [key: string]: string }> = [];
+
+    const rows = await tableElement.$$("tbody tr");
+    const headerRow = await tableElement.$("thead tr");
+    const headerColumns = await headerRow.$$("th");
+
+    const columnHeaders = await Promise.all(
+      headerColumns.map(async (headerColumn) => await headerColumn.getText())
+    );
+
+    for (const row of rows) {
+      const columns = await row.$$("th,td");
+      const rowData: { [key: string]: string } = {};
+
+      for (const [index, header] of columnHeaders.entries()) {
+        rowData[header] = await columns[index].getText();
+      }
+
+      tableData.push(rowData);
+    }
+    return tableData;
+  }
+
+  public async getBreadcrumbs(): Promise<string[]> {
+    const breadcrumbsElements = await this.breadcrumbs;
+    const breadcrumbs: string[] = [];
+
+    for (const element of breadcrumbsElements) {
+      const text = await element.getText();
+      breadcrumbs.push(text);
+    }
+    return breadcrumbs;
   }
 }

--- a/ui-tests/specs/breadcrumbs.spec.ts
+++ b/ui-tests/specs/breadcrumbs.spec.ts
@@ -1,0 +1,28 @@
+import { waitForPageLoad } from "../helpers/waits";
+import HomePage from "../pageobjects/homepage";
+import InvoicePage from "../pageobjects/invoicePage";
+import InvoicesListPage from "../pageobjects/invoicesListPage";
+import ContractsPage from "../pageobjects/contractsPage";
+
+describe("Breadcrumbs Tests", () => {
+  before(async () => {
+    await browser.url(" ");
+    await waitForPageLoad();
+  });
+
+  it("Should display correct breadcrumbs", async () => {
+    let breadcrumbs = await HomePage.getBreadcrumbs();
+    expect(breadcrumbs.length).toBe(0);
+    await HomePage.clickOnViewInvoiceLink();
+    breadcrumbs = await HomePage.getBreadcrumbs();
+    expect(breadcrumbs.length).toBe(3);
+    await InvoicePage.clickOnInvoiceBreadcrumbsLink();
+    await waitForPageLoad();
+    breadcrumbs = await InvoicesListPage.getBreadcrumbs();
+    expect(breadcrumbs.length).toBe(2);
+    await InvoicesListPage.clickOnContractsBreadcrumbsLink();
+    await waitForPageLoad();
+    breadcrumbs = await ContractsPage.getBreadcrumbs();
+    expect(breadcrumbs.length).toBe(1);
+  });
+});

--- a/ui-tests/specs/breadcrumbs.spec.ts
+++ b/ui-tests/specs/breadcrumbs.spec.ts
@@ -2,7 +2,15 @@ import { waitForPageLoad } from "../helpers/waits";
 import HomePage from "../pageobjects/homepage";
 import InvoicePage from "../pageobjects/invoicePage";
 import InvoicesListPage from "../pageobjects/invoicesListPage";
-import ContractsPage from "../pageobjects/contractsPage";
+import Page from "../pageobjects/page";
+
+const checkBreadcrumbsCount = async (
+  page: Page,
+  expectedCount: number
+): Promise<void> => {
+  const breadcrumbs = await page.getBreadcrumbs();
+  expect(breadcrumbs.length).toBe(expectedCount);
+};
 
 describe("Breadcrumbs Tests", () => {
   before(async () => {
@@ -11,18 +19,16 @@ describe("Breadcrumbs Tests", () => {
   });
 
   it("Should display correct breadcrumbs", async () => {
-    let breadcrumbs = await HomePage.getBreadcrumbs();
-    expect(breadcrumbs.length).toBe(0);
+    await checkBreadcrumbsCount(HomePage, 0);
     await HomePage.clickOnViewInvoiceLink();
-    breadcrumbs = await HomePage.getBreadcrumbs();
-    expect(breadcrumbs.length).toBe(3);
+    await checkBreadcrumbsCount(HomePage, 3);
+
     await InvoicePage.clickOnInvoiceBreadcrumbsLink();
     await waitForPageLoad();
-    breadcrumbs = await InvoicesListPage.getBreadcrumbs();
-    expect(breadcrumbs.length).toBe(2);
+    await checkBreadcrumbsCount(InvoicesListPage, 2);
+
     await InvoicesListPage.clickOnContractsBreadcrumbsLink();
     await waitForPageLoad();
-    breadcrumbs = await ContractsPage.getBreadcrumbs();
-    expect(breadcrumbs.length).toBe(1);
+    await checkBreadcrumbsCount(InvoicesListPage, 1);
   });
 });

--- a/ui-tests/specs/breadcrumbs.spec.ts
+++ b/ui-tests/specs/breadcrumbs.spec.ts
@@ -18,7 +18,7 @@ describe("Breadcrumbs Tests", () => {
     await waitForPageLoad();
   });
 
-  it("Should display correct breadcrumbs", async () => {
+  it("Should display the expected number of breadcrumbs on each page", async () => {
     await checkBreadcrumbsCount(HomePage, 0);
     await HomePage.clickOnViewInvoiceLink();
     await checkBreadcrumbsCount(HomePage, 3);

--- a/ui-tests/specs/home.spec.ts
+++ b/ui-tests/specs/home.spec.ts
@@ -26,6 +26,19 @@ describe("Home Page Tests", () => {
     );
   });
 
+  it("Should navigate to the Contracts page when clicked on the link", async () => {
+    await HomePage.clickOnContractsPageLink();
+    const newPageUrl = await browser.getUrl();
+    expect(newPageUrl).toMatch(/contracts$/);
+  });
+});
+
+describe("Home Page Overview table Tests", () => {
+  beforeEach(async () => {
+    await browser.url(" ");
+    await waitForPageLoad();
+  });
+
   it("Should display the overview table with correct data", async () => {
     const tableData = await HomePage.getTableData(await HomePage.overViewTable);
     const expectedTableDataFromJson = getLatestInvoicePerVendor().map(
@@ -36,21 +49,27 @@ describe("Home Page Tests", () => {
             parseFloat(invoice.price_difference_percentage)
           );
         return {
-          "Contract Name": invoice.contract_name,
-          Vendor: invoice.vendor_name,
-          Month: `${monthString} ${invoice.year}`,
-          "Reconciliation Details":
+          contractName: invoice.contract_name,
+          vendor: invoice.vendor_name,
+          month: `${monthString} ${invoice.year}`,
+          reconciliationDetails:
             reconciliationDetails.bannerMessage.toUpperCase(),
-          Details: "View Invoice",
+          details: "View Invoice",
         };
       }
     );
-    const sortTableDataByVendor = Array.from(tableData).sort((a, b) =>
-      a.Vendor.localeCompare(b.Vendor)
-    );
+    const sortTableDataByVendor = tableData
+      .map((data) => ({
+        contractName: data["Contract Name"],
+        vendor: data.Vendor,
+        month: data.Month,
+        reconciliationDetails: data["Reconciliation Details"],
+        details: data.Details,
+      }))
+      .sort((a, b) => a.vendor.localeCompare(b.vendor));
 
     const sortedExpectedData = Array.from(expectedTableDataFromJson).sort(
-      (a, b) => a.Vendor.localeCompare(b.Vendor)
+      (a, b) => a.vendor.localeCompare(b.vendor)
     );
     expect(sortedExpectedData).toEqual(sortTableDataByVendor);
   });
@@ -76,18 +95,12 @@ describe("Home Page Tests", () => {
       `${firstInvoice.contract_id}/invoices/${firstInvoice.year}-${firstInvoice.month}`
     );
   });
-
-  it("Should navigate to the Contracts page when clicked on the link", async () => {
-    await HomePage.clickOnContractsPageLink();
-    const newPageUrl = await browser.getUrl();
-    expect(newPageUrl).toMatch(/contracts$/);
-  });
 });
 
 export type OverviewTable = {
-  "Contract Name": string;
-  Vendor: string;
-  Month: string;
-  "Reconciliation Details": string;
-  Details: string;
+  contractName: string;
+  vendor: string;
+  month: string;
+  reconciliationDetails: string;
+  details: string;
 };

--- a/ui-tests/specs/home.spec.ts
+++ b/ui-tests/specs/home.spec.ts
@@ -54,6 +54,28 @@ describe("Home Page Tests", () => {
     expect(sortedExpectedData).toEqual(sortedTableData);
   });
 
+  it(`Should navigate to the correct contract page on "Contract Name" click`, async () => {
+    const firstInvoice = getLatestInvoicePerVendor().sort((a, b) =>
+      a.contract_name.localeCompare(b.contract_name)
+    )[0];
+    await HomePage.clickOnFirstContractInTable();
+    await waitForPageLoad();
+    expect(await browser.getUrl()).toContain(
+      `${firstInvoice.contract_id}/invoices`
+    );
+  });
+
+  it(`Should navigate to the correct invoice page on "View Invoice" click`, async () => {
+    const firstInvoice = getLatestInvoicePerVendor().sort((a, b) =>
+      a.contract_name.localeCompare(b.contract_name)
+    )[0];
+    await HomePage.clickOnViewInvoiceLink();
+    await waitForPageLoad();
+    expect(await browser.getUrl()).toContain(
+      `${firstInvoice.contract_id}/invoices/${firstInvoice.year}-${firstInvoice.month}`
+    );
+  });
+
   it("Should navigate to the Contracts page when clicked on the link", async () => {
     await HomePage.clickOnContractsPageLink();
     const newPageUrl = await browser.getUrl();

--- a/ui-tests/specs/home.spec.ts
+++ b/ui-tests/specs/home.spec.ts
@@ -58,7 +58,7 @@ describe("Home Page Overview table Tests", () => {
         };
       }
     );
-    const sortTableDataByVendor = tableData
+    const sortedTableDataByVendor = tableData
       .map((data) => ({
         contractName: data["Contract Name"],
         vendor: data.Vendor,
@@ -71,7 +71,7 @@ describe("Home Page Overview table Tests", () => {
     const sortedExpectedData = Array.from(expectedTableDataFromJson).sort(
       (a, b) => a.vendor.localeCompare(b.vendor)
     );
-    expect(sortedExpectedData).toEqual(sortTableDataByVendor);
+    expect(sortedExpectedData).toEqual(sortedTableDataByVendor);
   });
 
   it(`Should navigate to the correct contract page on "Contract Name" click`, async () => {

--- a/ui-tests/specs/home.spec.ts
+++ b/ui-tests/specs/home.spec.ts
@@ -1,5 +1,8 @@
 import { waitForPageLoad } from "../helpers/waits";
 import HomePage from "../pageobjects/homepage";
+import { getLatestInvoicePerVendor } from "../utils/extractTestDatajson";
+import { prettyMonthName } from "../utils/getPrettyMonthName";
+import { generateExpectedBannerDetailsFromPercentagePriceDifference } from "../utils/generateExpectedStatusBannerDetails";
 
 /* UI tests for Home Page. It verifies the page displays the correct heading and subheading.
 It also tests the navigation to the contract list page when the link is clicked */
@@ -23,9 +26,32 @@ describe("Home Page Tests", () => {
     );
   });
 
-  it.only("Should display the overview table with correct data", async () => {
+  it("Should display the overview table with correct data", async () => {
     const tableData = await HomePage.getTableData(await HomePage.overViewTable);
-    console.log(tableData);
+    const expectedTableDataFromJson = getLatestInvoicePerVendor().map(
+      (invoice): OverviewTable => {
+        const monthString = prettyMonthName(invoice.month);
+        const reconciliationDetails =
+          generateExpectedBannerDetailsFromPercentagePriceDifference(
+            parseFloat(invoice.price_difference_percentage)
+          );
+        return {
+          "Contract Name": invoice.contract_name,
+          Vendor: invoice.vendor_name,
+          Month: `${monthString} ${invoice.year}`,
+          "Reconciliation Details":
+            reconciliationDetails.bannerMessage.toUpperCase(),
+          Details: "View Invoice",
+        };
+      }
+    );
+    const sortedTableData = tableData.sort((a, b) =>
+      a.Vendor.localeCompare(b.Vendor)
+    );
+    const sortedExpectedData = expectedTableDataFromJson.sort((a, b) =>
+      a.Vendor.localeCompare(b.Vendor)
+    );
+    expect(sortedExpectedData).toEqual(sortedTableData);
   });
 
   it("Should navigate to the Contracts page when clicked on the link", async () => {
@@ -34,3 +60,11 @@ describe("Home Page Tests", () => {
     expect(newPageUrl).toMatch(/contracts$/);
   });
 });
+
+export type OverviewTable = {
+  "Contract Name": string;
+  Vendor: string;
+  Month: string;
+  "Reconciliation Details": string;
+  Details: string;
+};

--- a/ui-tests/specs/home.spec.ts
+++ b/ui-tests/specs/home.spec.ts
@@ -23,6 +23,11 @@ describe("Home Page Tests", () => {
     );
   });
 
+  it.only("Should display the overview table with correct data", async () => {
+    const tableData = await HomePage.getTableData(await HomePage.overViewTable);
+    console.log(tableData);
+  });
+
   it("Should navigate to the Contracts page when clicked on the link", async () => {
     await HomePage.clickOnContractsPageLink();
     const newPageUrl = await browser.getUrl();

--- a/ui-tests/specs/home.spec.ts
+++ b/ui-tests/specs/home.spec.ts
@@ -45,13 +45,14 @@ describe("Home Page Tests", () => {
         };
       }
     );
-    const sortedTableData = tableData.sort((a, b) =>
+    const sortTableDataByVendor = Array.from(tableData).sort((a, b) =>
       a.Vendor.localeCompare(b.Vendor)
     );
-    const sortedExpectedData = expectedTableDataFromJson.sort((a, b) =>
-      a.Vendor.localeCompare(b.Vendor)
+
+    const sortedExpectedData = Array.from(expectedTableDataFromJson).sort(
+      (a, b) => a.Vendor.localeCompare(b.Vendor)
     );
-    expect(sortedExpectedData).toEqual(sortedTableData);
+    expect(sortedExpectedData).toEqual(sortTableDataByVendor);
   });
 
   it(`Should navigate to the correct contract page on "Contract Name" click`, async () => {

--- a/ui-tests/utils/extractTestDatajson.ts
+++ b/ui-tests/utils/extractTestDatajson.ts
@@ -145,3 +145,27 @@ export const extractAllUniqueVendorInvoiceDataFomJson = (
   }
   return allVendorInvoiceData;
 };
+
+export const getLatestInvoicePerVendor = (): FullExtractData[] => {
+  const testDataFilePath = getTestDataFilePath();
+  const data = getExtractDataFromJson(testDataFilePath);
+
+  // sort data by vendor year and month
+  const sortedData = [...data].sort((a, b) => {
+    if (a.vendor_name !== b.vendor_name)
+      return a.vendor_name.localeCompare(b.vendor_name);
+    if (a.year !== b.year) return parseInt(b.year) - parseInt(a.year);
+    return parseInt(b.month) - parseInt(a.month);
+  });
+
+  // Filter latest invoice
+  const latestInvoices: FullExtractData[] = [];
+  let currentVendor = "";
+  for (const entry of sortedData) {
+    if (entry.vendor_name !== currentVendor) {
+      latestInvoices.push(entry);
+      currentVendor = entry.vendor_name;
+    }
+  }
+  return latestInvoices;
+};

--- a/ui-tests/utils/extractTestDatajson.ts
+++ b/ui-tests/utils/extractTestDatajson.ts
@@ -161,10 +161,10 @@ export const getLatestInvoicePerVendor = (): FullExtractData[] => {
   // Filter latest invoice
   const latestInvoices: FullExtractData[] = [];
   let currentVendor = "";
-  for (const entry of sortedData) {
-    if (entry.vendor_name !== currentVendor) {
-      latestInvoices.push(entry);
-      currentVendor = entry.vendor_name;
+  for (const invoice of sortedData) {
+    if (invoice.vendor_name !== currentVendor) {
+      latestInvoices.push(invoice);
+      currentVendor = invoice.vendor_name;
     }
   }
   return latestInvoices;

--- a/ui-tests/utils/getPrettyMonthName.ts
+++ b/ui-tests/utils/getPrettyMonthName.ts
@@ -1,0 +1,5 @@
+export const prettyMonthName = (monthNumber: string): string => {
+  const date = new Date(0, parseInt(monthNumber) - 1);
+  const monthName = date.toLocaleString("default", { month: "short" });
+  return monthName;
+};


### PR DESCRIPTION
Added below additional UI tests 

- HomepageOverview table Tests:
This tests verifies that the data displayed in the Overview table on the homepage matches with data retrieved from the latest invoices per vendor from json tests data file. 
Also, added tests to verify the correct navigation to respective contract and invoice page when contract name and vie w invoice links are clicked.

- Breadcrumbs tests
Added new suite of tests to validate the breadcrumb count to ensure that the navigation breadcrumbs are working as expected.

- moved getTable function to page file so that can be reused in homepage and invoice page tests
- Added a getLatestInvoicesByVendor to get the latest invoices per vendor to compare with UI
- Added a file getPrerttyMonth the function takes month number as input and returns the corresponding short form of the month name to compare it with UI data
