### PR TITLE
BTM-712 Now exclude empty rows from overview table

### DIFF
--- a/src/frontend/extract-helpers/get-overview-rows.test.ts
+++ b/src/frontend/extract-helpers/get-overview-rows.test.ts
@@ -24,13 +24,16 @@ describe("getOverviewRows", () => {
 
     // Arrange
     mockedGetContracts.mockResolvedValue([
+      { id: "nc1", name: "NewContract", vendorName: "New Vendor" },
       { id: "c1", name: "C01234", vendorName: "Vendor One" },
       { id: "m2", name: "MOU", vendorName: "Vendor Two" },
     ]);
-    mockedGetContractPeriods.mockResolvedValue([
-      { month: "05", prettyMonth: "May", year: "2023" },
-      { month: "06", prettyMonth: "Jun", year: "2023" },
-    ]);
+    mockedGetContractPeriods
+      .mockResolvedValueOnce([]) // New contract has no data
+      .mockResolvedValue([
+        { month: "05", prettyMonth: "May", year: "2023" },
+        { month: "06", prettyMonth: "Jun", year: "2023" },
+      ]);
     mockedGetLineItems
       .mockResolvedValueOnce([
         {
@@ -93,8 +96,9 @@ describe("getOverviewRows", () => {
     // Act
     const result = await getOverviewRows();
     // Assert
-    expect(mockedGetContractPeriods).toHaveBeenNthCalledWith(1, "c1");
-    expect(mockedGetContractPeriods).toHaveBeenNthCalledWith(2, "m2");
+    expect(mockedGetContractPeriods).toHaveBeenNthCalledWith(1, "nc1");
+    expect(mockedGetContractPeriods).toHaveBeenNthCalledWith(2, "c1");
+    expect(mockedGetContractPeriods).toHaveBeenNthCalledWith(3, "m2");
 
     expect(mockedGetLineItems).toHaveBeenNthCalledWith(1, "c1", "2023", "06");
     expect(mockedGetLineItems).toHaveBeenNthCalledWith(2, "m2", "2023", "06");

--- a/src/frontend/extract-helpers/get-overview-rows.ts
+++ b/src/frontend/extract-helpers/get-overview-rows.ts
@@ -23,30 +23,32 @@ export const getOverviewRows = async (): Promise<OverviewRow[]> => {
   const contracts = await getContracts();
   for (const contract of contracts) {
     const latestMonth = await getRecentMonth(contract.id);
-    const reconciliationDetails = await getReconciliationDetails(
-      contract.id,
-      latestMonth.year,
-      latestMonth.month
-    );
-    const row = {
-      contractLinkData: {
-        href: getUrl(invoicesPage, { contract_id: contract.id }),
-        text: contract.name,
-      },
-      vendorName: contract.vendorName,
-      year: latestMonth.year,
-      prettyMonth: latestMonth.prettyMonth,
-      reconciliationDetails,
-      invoiceLinkData: {
-        href: getUrl(invoicePage, {
-          contract_id: contract.id,
-          month: latestMonth.month,
-          year: latestMonth.year,
-        }),
-        text: "View Invoice",
-      },
-    };
-    overviewRows.push(row);
+    if (latestMonth) {
+      const reconciliationDetails = await getReconciliationDetails(
+        contract.id,
+        latestMonth.year,
+        latestMonth.month
+      );
+      const row = {
+        contractLinkData: {
+          href: getUrl(invoicesPage, { contract_id: contract.id }),
+          text: contract.name,
+        },
+        vendorName: contract.vendorName,
+        year: latestMonth.year,
+        prettyMonth: latestMonth.prettyMonth,
+        reconciliationDetails,
+        invoiceLinkData: {
+          href: getUrl(invoicePage, {
+            contract_id: contract.id,
+            month: latestMonth.month,
+            year: latestMonth.year,
+          }),
+          text: "View Invoice",
+        },
+      };
+      overviewRows.push(row);
+    }
   }
   return overviewRows;
 };
@@ -55,8 +57,7 @@ const getRecentMonth = async (
   contractId: string
 ): Promise<{ month: string; year: string; prettyMonth: string }> => {
   const contractPeriods = await getContractPeriods(contractId);
-  const latestPeriod = contractPeriods[contractPeriods.length - 1];
-  return latestPeriod;
+  return contractPeriods[contractPeriods.length - 1];
 };
 
 const getReconciliationDetails = async (


### PR DESCRIPTION
Vendors which appear in config but for which we have no data to show were causing crashes when the home page tries to render the overview table.  This change causes such rows to be left off the table, which is our James-approved fix for the time being.