### PR TITLE
BTM-737 cookies page navigation test

### DIFF
--- a/ui-tests/pageobjects/page.ts
+++ b/ui-tests/pageobjects/page.ts
@@ -15,6 +15,10 @@ export default class Page {
     return $$("li.govuk-breadcrumbs__list-item");
   }
 
+  public get cookiesFooterLink(): Promise<WebdriverIO.Element> {
+    return $('a[href="/cookies"]');
+  }
+
   public async isPageHeadingDisplayed(): Promise<boolean> {
     return await (await this.pageHeading).isDisplayed();
   }
@@ -66,5 +70,9 @@ export default class Page {
       breadcrumbs.push(text);
     }
     return breadcrumbs;
+  }
+
+  public async clickOnCookiesFooterLink(): Promise<void> {
+    await (await this.cookiesFooterLink).click();
   }
 }

--- a/ui-tests/specs/footer.spec.ts
+++ b/ui-tests/specs/footer.spec.ts
@@ -1,0 +1,16 @@
+import { waitForPageLoad } from "../helpers/waits";
+import HomePage from "../pageobjects/homepage";
+
+describe("Footer Tests", () => {
+  before(async () => {
+    await browser.url(" ");
+    await waitForPageLoad();
+  });
+
+  it("Should navigate to the Cookies page when clicked on the footer cookies link", async () => {
+    await HomePage.clickOnCookiesFooterLink();
+    expect(await browser.getUrl()).toContain("cookies");
+    expect(await HomePage.isPageSubHeadingDisplayed()).toBe(true);
+    expect(await HomePage.getPageSubHeadingText()).toEqual("Cookies");
+  });
+});


### PR DESCRIPTION
In this PR, I have added UI test to ensure that clicking on Cookies link in the footer navigates to correct Cookies page by verifying the url and page title. 
-Added a. new file called footer.spec.ts and this file contains one test that checks the functionality of the cookies link in the footer. 
-Added cookies link web element and click action on page.ts file.
I haven't added test to check the content of the page as the content may not change often.
