### PR TITLE
BTM-738 Dynamic base url selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,9 +156,17 @@ so that the parser can be re-run on specific data after the parser is updated. T
 If you update a parser, please increment its version!
 
 ## Running UI Tests
-Update the `baseURl` in the `wdio.conf.ts` config file. Set it to the desired base URL
 
-Run the following command to run the UI tests
+Our UI testing suite determines which environment to use based on the `ENV_NAME` environment variable. `ENV_NAME` is used to select the corresponding
+base URL from the configuration un the `wdio.conf.ts` file.
+
+If `ENV_NAME` is not set or if its set to a value other than "dev","build" or "staging", the baseURL defaults to the local URL which is http://localhost:3000 . This allows test to be run against local development environment by default.
+
+The `ENV_NAME` variable is also used when uploading the extract test data file to S3 bucket. The test data file will be uploaded to the bucket corresponding to the specified environment ("dev","build" or "staging").
+
+## Running All UI Tests
+
+Run the following command to run all the UI tests
 
 ```sh
 npm run test:ui

--- a/wdio.conf.ts
+++ b/wdio.conf.ts
@@ -4,6 +4,7 @@ const BASE_URLS = {
   local: "http://localhost:3000",
   dev: "https://btm.dev.account.gov.uk/",
   build: "https://btm.build.account.gov.uk/",
+  staging: "https://btm.staging.account.gov.uk/",
 };
 
 export const config = {
@@ -15,7 +16,7 @@ export const config = {
       project: "./tsconfig.json",
     },
   },
-  specs: ["./ui-tests/specs/home.spec.ts"],
+  specs: ["./ui-tests/specs/**/*.spec.ts"],
   maxInstances: 10,
   capabilities: [
     {

--- a/wdio.conf.ts
+++ b/wdio.conf.ts
@@ -1,11 +1,20 @@
 import { uploadExtractDataFileForUITest } from "./ui-tests/testData/test.setup";
 
-const BASE_URLS = {
+type Environment = "dev" | "build" | "staging";
+
+const baseUrls = {
   local: "http://localhost:3000",
   dev: "https://btm.dev.account.gov.uk/",
   build: "https://btm.build.account.gov.uk/",
   staging: "https://btm.staging.account.gov.uk/",
 };
+
+const env =
+  (process.env.ENV_NAME as Environment) in baseUrls
+    ? (process.env.ENV_NAME as Environment)
+    : "local";
+
+const baseUrl = baseUrls[env];
 
 export const config = {
   runner: "local",
@@ -28,8 +37,7 @@ export const config = {
   ],
   logLevel: "error",
   bail: 0,
-  baseUrl:
-    BASE_URLS[process.env.ENV as keyof typeof BASE_URLS] ?? BASE_URLS.dev,
+  baseUrl,
   waitforTimeout: 10000,
   connectionRetryTimeout: 120000,
   connectionRetryCount: 3,

--- a/wdio.conf.ts
+++ b/wdio.conf.ts
@@ -1,5 +1,11 @@
 import { uploadExtractDataFileForUITest } from "./ui-tests/testData/test.setup";
 
+const BASE_URLS = {
+  local: "http://localhost:3000",
+  dev: "https://btm.dev.account.gov.uk/",
+  build: "https://btm.build.account.gov.uk/",
+};
+
 export const config = {
   runner: "local",
   autoCompileOpts: {
@@ -9,7 +15,7 @@ export const config = {
       project: "./tsconfig.json",
     },
   },
-  specs: ["./ui-tests/specs/**/*.spec.ts"],
+  specs: ["./ui-tests/specs/home.spec.ts"],
   maxInstances: 10,
   capabilities: [
     {
@@ -21,7 +27,7 @@ export const config = {
   ],
   logLevel: "error",
   bail: 0,
-  baseUrl: "",
+  baseUrl: BASE_URLS[process.env.NODE_ENV as keyof typeof BASE_URLS],
   waitforTimeout: 10000,
   connectionRetryTimeout: 120000,
   connectionRetryCount: 3,

--- a/wdio.conf.ts
+++ b/wdio.conf.ts
@@ -28,7 +28,8 @@ export const config = {
   ],
   logLevel: "error",
   bail: 0,
-  baseUrl: BASE_URLS[process.env.NODE_ENV as keyof typeof BASE_URLS],
+  baseUrl:
+    BASE_URLS[process.env.ENV as keyof typeof BASE_URLS] ?? BASE_URLS.dev,
   waitforTimeout: 10000,
   connectionRetryTimeout: 120000,
   connectionRetryCount: 3,


### PR DESCRIPTION
This PR modifies the configuration setup for our UI tests to dynamically choose the base URL based on `ENV_NAME` environment variable. This  enables us to easily switch between different environments during testing.

-Updated `wdio.conf.ts` to include condition that checks `ENV_NAME` environment variable and assigns the baseURL accordingly.
-Updated README.md to include information on how to set `ENV_NAME` and how it influences the tests and S3 extract test data file uploads.