### PR TITLE
BTM-713 currency fix encoding issue and optimise ui test data upload

### DIFF
--- a/src/handlers/int-test-support/helpers/s3Helper.ts
+++ b/src/handlers/int-test-support/helpers/s3Helper.ts
@@ -127,7 +127,8 @@ const getS3ObjectBasic = async (
 export const getS3Object = callWithRetryAndTimeout(getS3ObjectBasic);
 
 const putS3ObjectBasic = async (
-  dataAndTarget: DataAndTarget
+  dataAndTarget: DataAndTarget,
+  encoding: BufferEncoding = "ascii" // default encoding ascii
 ): Promise<void> => {
   if (runViaLambda()) {
     await sendLambdaCommand(IntTestHelpers.putS3Object, dataAndTarget);
@@ -137,7 +138,7 @@ const putS3ObjectBasic = async (
   const bucketParams = {
     Bucket: dataAndTarget.target.bucket,
     Key: dataAndTarget.target.key,
-    Body: Buffer.from(dataAndTarget.data, "ascii"),
+    Body: Buffer.from(dataAndTarget.data, encoding),
   };
   try {
     await s3Client.send(new PutObjectCommand(bucketParams));

--- a/ui-tests/testData/test.setup.ts
+++ b/ui-tests/testData/test.setup.ts
@@ -9,7 +9,7 @@ import { readJsonDataFromFile } from "../utils/extractTestDatajson";
 const prefix = resourcePrefix();
 const storageBucket = `${prefix}-storage`;
 
-export const cleanAndUploadFileForUITest = async (): Promise<void> => {
+export const cleanAndUploadExtractFileForUITest = async (): Promise<void> => {
   const key = "btm_extract_data/full-extract.json";
   const filePath = "./ui-tests/testData/testData.json";
   const content = readJsonDataFromFile(filePath);

--- a/ui-tests/testData/test.setup.ts
+++ b/ui-tests/testData/test.setup.ts
@@ -13,7 +13,11 @@ export const cleanAndUploadFileForUITest = async (): Promise<void> => {
   const key = "btm_extract_data/full-extract.json";
   const filePath = "./ui-tests/testData/testData.json";
   const content = readJsonDataFromFile(filePath);
+
+  // deleting existing file with same key
   await deleteS3Objects({ bucket: storageBucket, keys: [key] });
+
+  // uploading the file to s3
   await putS3Object(
     {
       data: content,
@@ -25,6 +29,7 @@ export const cleanAndUploadFileForUITest = async (): Promise<void> => {
     "utf-8"
   );
 
+  // verifying that the file exists
   const objectExists = await checkIfS3ObjectExists({
     bucket: storageBucket,
     key,

--- a/ui-tests/testData/test.setup.ts
+++ b/ui-tests/testData/test.setup.ts
@@ -1,18 +1,38 @@
 import { resourcePrefix } from "../../src/handlers/int-test-support/helpers/envHelper";
-import { putS3Object } from "../../src/handlers/int-test-support/helpers/s3Helper";
+import {
+  deleteS3Objects,
+  putS3Object,
+  checkIfS3ObjectExists,
+} from "../../src/handlers/int-test-support/helpers/s3Helper";
 import { readJsonDataFromFile } from "../utils/extractTestDatajson";
 
 const prefix = resourcePrefix();
 const storageBucket = `${prefix}-storage`;
 
-export const uploadExtractDataFileForUITest = async (): Promise<void> => {
+export const cleanAndUploadFileForUITest = async (): Promise<void> => {
+  const key = "btm_extract_data/full-extract.json";
   const filePath = "./ui-tests/testData/testData.json";
   const content = readJsonDataFromFile(filePath);
-  await putS3Object({
-    data: content,
-    target: {
-      bucket: storageBucket,
-      key: `btm_extract_data/full-extract.json`,
+  await deleteS3Objects({ bucket: storageBucket, keys: [key] });
+  await putS3Object(
+    {
+      data: content,
+      target: {
+        bucket: storageBucket,
+        key,
+      },
     },
+    "utf-8"
+  );
+
+  const objectExists = await checkIfS3ObjectExists({
+    bucket: storageBucket,
+    key,
   });
+
+  if (!objectExists) {
+    throw new Error(
+      `Failed to verify that the file was uploaded to ${storageBucket}/${key}`
+    );
+  }
 };

--- a/wdio.conf.ts
+++ b/wdio.conf.ts
@@ -1,4 +1,4 @@
-import { uploadExtractDataFileForUITest } from "./ui-tests/testData/test.setup";
+import { cleanAndUploadExtractFileForUITest } from "./ui-tests/testData/test.setup";
 
 const determineBaseUrl = (): string => {
   switch (process.env.ENV_NAME) {
@@ -23,7 +23,7 @@ export const config = {
       project: "./tsconfig.json",
     },
   },
-  specs: ["./ui-tests/specs/**/*.spec.ts"],
+  specs: ["./ui-tests/specs/invoice.spec.ts"],
   maxInstances: 10,
   capabilities: [
     {
@@ -46,7 +46,7 @@ export const config = {
     ui: "bdd",
     timeout: 60000,
   },
-  beforeTest: async function () {
-    await uploadExtractDataFileForUITest();
+  onPrepare: async function () {
+    await cleanAndUploadExtractFileForUITest();
   },
 };


### PR DESCRIPTION
This PR addresses an issue where the currency symbol £ was being incorrectly encoded when uploading a test data file to s3. The root cause was found to be `ASCII` encoding used in putObject function.

- Modified putS3objectBasic function to accept an optional  encoding parameter. By default the encoding set to ASCII  but now it can be overridden. If UTF-8 is specified it will be used to correctly handle characters like £.
- Updated UI test data file uploading mechanism,Previously the upload was happening before each test now I changed this to onPrepare function so it is executed once.
-  Renamed `uploadExtractDataFileForUITest` function to cleanAndUploadExtractFileForUITest  and added deletion of existing file in s3 and uploading new ones.
