### PR TITLE
Btm 767 fix UI tests invoice status and color

### DIFF
--- a/ui-tests/specs/home.spec.ts
+++ b/ui-tests/specs/home.spec.ts
@@ -2,7 +2,7 @@ import { waitForPageLoad } from "../helpers/waits";
 import HomePage from "../pageobjects/homepage";
 import { getLatestInvoicePerVendor } from "../utils/extractTestDatajson";
 import { prettyMonthName } from "../utils/getPrettyMonthName";
-import { generateExpectedBannerDetailsFromPercentagePriceDifference } from "../utils/generateExpectedStatusBannerDetails";
+import { generateExpectedOverviewTableStatusFromPercentagePriceDifference } from "../utils/generateExpectedOverviewTableStatus";
 
 /* UI tests for Home Page. It verifies the page displays the correct heading and subheading.
 It also tests the navigation to the contract list page when the link is clicked */
@@ -45,15 +45,14 @@ describe("Home Page Overview table Tests", () => {
       (invoice): OverviewTable => {
         const monthString = prettyMonthName(invoice.month);
         const reconciliationDetails =
-          generateExpectedBannerDetailsFromPercentagePriceDifference(
+          generateExpectedOverviewTableStatusFromPercentagePriceDifference(
             parseFloat(invoice.price_difference_percentage)
           );
         return {
           contractName: invoice.contract_name,
           vendor: invoice.vendor_name,
           month: `${monthString} ${invoice.year}`,
-          reconciliationDetails:
-            reconciliationDetails.bannerMessage.toUpperCase(),
+          reconciliationDetails,
           details: "View Invoice",
         };
       }

--- a/ui-tests/specs/invoice.spec.ts
+++ b/ui-tests/specs/invoice.spec.ts
@@ -185,7 +185,7 @@ const assertMeasuredTableData = (
   filteredItem: FullExtractData
 ): void => {
   // currently in ui it is Line Item instead of Line item, once fixed the tests will pass
-  expectEqual(tableRow["Line item"], filteredItem.service_name);
+  expectEqual(tableRow["Line Item"], filteredItem.service_name);
   expectEqual(tableRow.Quantity, filteredItem.transaction_quantity);
 };
 
@@ -194,7 +194,7 @@ const assertInvoiceTableData = (
   filteredItem: FullExtractData
 ): void => {
   // currently in ui it is Line Item instead of Line item, once fixed the tests will pass
-  expectEqual(tableRow["Line item"], filteredItem.service_name);
+  expectEqual(tableRow["Line Item"], filteredItem.service_name);
   expectEqual(tableRow.Quantity, filteredItem.billing_quantity);
   expectEqual(tableRow["Unit price"], filteredItem.billing_unit_price);
   expectEqual(tableRow.Total, filteredItem.billing_price_formatted);

--- a/ui-tests/specs/invoice.spec.ts
+++ b/ui-tests/specs/invoice.spec.ts
@@ -185,7 +185,7 @@ const assertMeasuredTableData = (
   filteredItem: FullExtractData
 ): void => {
   // currently in ui it is Line Item instead of Line item, once fixed the tests will pass
-  expectEqual(tableRow["Line Item"], filteredItem.service_name);
+  expectEqual(tableRow["Line item"], filteredItem.service_name);
   expectEqual(tableRow.Quantity, filteredItem.transaction_quantity);
 };
 
@@ -194,7 +194,7 @@ const assertInvoiceTableData = (
   filteredItem: FullExtractData
 ): void => {
   // currently in ui it is Line Item instead of Line item, once fixed the tests will pass
-  expectEqual(tableRow["Line Item"], filteredItem.service_name);
+  expectEqual(tableRow["Line item"], filteredItem.service_name);
   expectEqual(tableRow.Quantity, filteredItem.billing_quantity);
   expectEqual(tableRow["Unit price"], filteredItem.billing_unit_price);
   expectEqual(tableRow.Total, filteredItem.billing_price_formatted);

--- a/ui-tests/utils/constants.ts
+++ b/ui-tests/utils/constants.ts
@@ -2,7 +2,7 @@ export const TEST_DATA_FILE_PATH = "../testData/testData.json";
 
 export enum InvoiceStates {
   invoiceAndEventsMissing = "Invoice and events missing",
-  noCharge = "No charge",
+  noCharge = "Invoice has no charge",
   unableToFindRate = "Unable to find rate",
   invoiceDataMissing = "Invoice data missing",
   eventsMissing = "Events missing",
@@ -17,32 +17,48 @@ export enum Color {
   grey = "#b1b4b6",
   blue = "#1d70b8",
   red = "#d4351c",
+  yellow = "#ffdd00",
 }
 
 export const statusLabels = {
   STATUS_LABEL_WITHIN_THRESHOLD: {
     message: "WITHIN THRESHOLD",
+    overviewTableStatus: "WITHIN THRESHOLD",
   },
   STATUS_LABEL_NO_CHARGE: {
     message: "NO CHARGE",
+    overviewTableStatus: "NO CHARGE",
   },
   STATUS_LABEL_BELOW_THRESHOLD: {
     message: "BELOW THRESHOLD",
+    overviewTableStatus: "BELOW THRESHOLD",
   },
   STATUS_LABEL_ABOVE_THRESHOLD: {
     message: "ABOVE THRESHOLD",
+    overviewTableStatus: "WARNING",
   },
-  STATUS_LABEL_PENDING: {
-    message: "PENDING",
+  STATUS_LABEL_INVOICE_MISSING: {
+    message: "INVOICE MISSING",
+    overviewTableStatus: "PENDING",
   },
-  STATUS_LABEL_ERROR: {
-    message: "ERROR",
+  STATUS_LABEL_RATE_MISSING: {
+    message: "RATE MISSING",
+    overviewTableStatus: "ERROR",
+  },
+  STATUS_LABEL_EVENTS_MISSING: {
+    message: "EVENTS MISSING",
+    overviewTableStatus: "ERROR",
+  },
+  STATUS_LABEL_UNEXPECTED_CHARGE: {
+    message: "UNEXPECTED CHARGE",
+    overviewTableStatus: "WARNING",
   },
 };
 
 export const percentageDiscrepancySpecialCase: Record<
   string,
   {
+    overviewTableStatus: string;
     bannerText: string;
     bannerColor: string;
     statusLabel: string;
@@ -50,33 +66,38 @@ export const percentageDiscrepancySpecialCase: Record<
   }
 > = {
   "-1234567.01": {
+    overviewTableStatus: "NO CHARGE",
     bannerText: InvoiceStates.noCharge,
     bannerColor: Color.green,
     statusLabel: statusLabels.STATUS_LABEL_NO_CHARGE.message,
     percentageDiscrepancy: InvoiceStates.noCharge,
   },
   "-1234567.02": {
+    overviewTableStatus: "ERROR",
     bannerText: InvoiceStates.unableToFindRate,
-    bannerColor: Color.grey,
-    statusLabel: statusLabels.STATUS_LABEL_ERROR.message,
+    bannerColor: Color.red,
+    statusLabel: statusLabels.STATUS_LABEL_RATE_MISSING.message,
     percentageDiscrepancy: InvoiceStates.unableToFindRate,
   },
   "-1234567.03": {
+    overviewTableStatus: "PENDING",
     bannerText: InvoiceStates.invoiceDataMissing,
-    bannerColor: Color.grey,
-    statusLabel: statusLabels.STATUS_LABEL_PENDING.message,
+    bannerColor: Color.blue,
+    statusLabel: statusLabels.STATUS_LABEL_INVOICE_MISSING.message,
     percentageDiscrepancy: InvoiceStates.invoiceDataMissing,
   },
   "-1234567.04": {
+    overviewTableStatus: "ERROR",
     bannerText: InvoiceStates.eventsMissing,
-    bannerColor: Color.grey,
-    statusLabel: statusLabels.STATUS_LABEL_ERROR.message,
+    bannerColor: Color.red,
+    statusLabel: statusLabels.STATUS_LABEL_EVENTS_MISSING.message,
     percentageDiscrepancy: InvoiceStates.eventsMissing,
   },
   "-1234567.05": {
+    overviewTableStatus: "WARNING",
     bannerText: InvoiceStates.unexpectedInvoiceCharge,
-    bannerColor: Color.grey,
-    statusLabel: statusLabels.STATUS_LABEL_ERROR.message,
+    bannerColor: Color.yellow,
+    statusLabel: statusLabels.STATUS_LABEL_UNEXPECTED_CHARGE.message,
     percentageDiscrepancy: InvoiceStates.unexpectedInvoiceCharge,
   },
 };

--- a/ui-tests/utils/generateExpectedOverviewTableStatus.ts
+++ b/ui-tests/utils/generateExpectedOverviewTableStatus.ts
@@ -1,0 +1,17 @@
+import { percentageDiscrepancySpecialCase, statusLabels } from "./constants";
+
+export const generateExpectedOverviewTableStatusFromPercentagePriceDifference =
+  (percentageDifference: number): string => {
+    if (percentageDiscrepancySpecialCase[percentageDifference]) {
+      return percentageDiscrepancySpecialCase[percentageDifference]
+        .overviewTableStatus;
+    }
+    if (percentageDifference > -1 && percentageDifference < 1) {
+      return percentageDiscrepancySpecialCase[percentageDifference]
+        .overviewTableStatus;
+    } else {
+      return percentageDifference > 1
+        ? statusLabels.STATUS_LABEL_ABOVE_THRESHOLD.overviewTableStatus
+        : statusLabels.STATUS_LABEL_BELOW_THRESHOLD.overviewTableStatus;
+    }
+  };

--- a/ui-tests/utils/generateExpectedStatusBannerDetails.ts
+++ b/ui-tests/utils/generateExpectedStatusBannerDetails.ts
@@ -18,10 +18,10 @@ export const generateExpectedBannerDetailsFromPercentagePriceDifference = (
     bannerColor = Color.green;
     bannerMessage = InvoiceStates.invoiceWithinThreshold;
   } else if (percentageDifference > 1) {
-    bannerColor = Color.red;
+    bannerColor = Color.yellow;
     bannerMessage = InvoiceStates.invoiceAboveThreshold;
   } else if (percentageDifference < -1) {
-    bannerColor = Color.blue;
+    bannerColor = Color.green;
     bannerMessage = InvoiceStates.invoiceBelowThreshold;
   } else {
     throw new Error(`Invalid percentageDifference: ${percentageDifference}`);


### PR DESCRIPTION
Add generateExpectedOverviewTableStatusFromPercentagePriceDifference module and utilised this function in home.spec.ts
Introduced `overviewTableStatus` in `statusLabels`
updated color codes in `percentageDiscrepencySpecialCase`
Modified the `generateExpectedBannerDetails` function to reflect new color codes