### PR TITLE
BTM-729 Tighten permissions on Textract DLQ

### DIFF
--- a/cloudformation/raw-invoice-textract-data-store.yaml
+++ b/cloudformation/raw-invoice-textract-data-store.yaml
@@ -33,7 +33,8 @@ Resources:
               ArnEquals:
                 aws:SourceArn: !Ref AmazonTextractRawInvoiceDataTopic
             Effect: Allow
-            Principal: '*'
+            Principal:
+              Service: sns.amazonaws.com
             Resource: !GetAtt AmazonTextractRawInvoiceDataTopicSubscriptionDeadLetterQueue.Arn
       Queues:
         - !Ref AmazonTextractRawInvoiceDataTopicSubscriptionDeadLetterQueue


### PR DESCRIPTION
Tightens the permissions on Textract DLQ, which formerly had '*' for the `Principal`.