### PR TITLE
BTM-718 Removed unused table columns

### DIFF
--- a/src/frontend/handlers/__snapshots__/home.test.ts.snap
+++ b/src/frontend/handlers/__snapshots__/home.test.ts.snap
@@ -148,17 +148,11 @@ exports[`home page handler Page displays all overview rows 1`] = `
         <th class="govuk-table__header govuk-!-width-one-quarter" scope="col">
   <a class="govuk-link" href="/contracts">Contracts</a>
 </th>
-        <th class="govuk-table__header govuk-!-width-one-quarter" scope="col"></th>
-        <th class="govuk-table__header govuk-!-width-one-quarter" scope="col"></th>
-        <th class="govuk-table__header govuk-!-width-one-quarter" scope="col"></th>
       </tr>
     </thead>
     <tbody class="govuk-table__body">
       <tr class="govuk-table__row">
         <td class="govuk-table__cell">All current and past contracts with invoices that have been reconciled.</td>
-        <td class="govuk-table__cell"></td>
-        <td class="govuk-table__cell"></td>
-        <td class="govuk-table__cell"></td>
       </tr>
     </tbody>
   </table>

--- a/src/frontend/views/home.njk
+++ b/src/frontend/views/home.njk
@@ -40,17 +40,11 @@
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
         <th class="govuk-table__header govuk-!-width-one-quarter" scope="col">{{ link(contractsLinkData) }}</th>
-        <th class="govuk-table__header govuk-!-width-one-quarter" scope="col"></th>
-        <th class="govuk-table__header govuk-!-width-one-quarter" scope="col"></th>
-        <th class="govuk-table__header govuk-!-width-one-quarter" scope="col"></th>
       </tr>
     </thead>
     <tbody class="govuk-table__body">
       <tr class="govuk-table__row">
         <td class="govuk-table__cell">All current and past contracts with invoices that have been reconciled.</td>
-        <td class="govuk-table__cell"></td>
-        <td class="govuk-table__cell"></td>
-        <td class="govuk-table__cell"></td>
       </tr>
     </tbody>
   </table>


### PR DESCRIPTION
Removed the empty columns that caused accessibility issues.

Note this causes the sole table column to widen a bit, but I don't think it looks bad:

![image](https://github.com/alphagov/di-billing-transaction-monitoring/assets/110683240/dd1fe5a2-0a23-41ec-908a-05db332f7bc1)
