### PR TITLE
Fix UI tests

### DIFF
--- a/src/handlers/int-test-support/helpers/s3Helper.ts
+++ b/src/handlers/int-test-support/helpers/s3Helper.ts
@@ -28,6 +28,7 @@ export type BucketAndPrefix = {
 
 type DataAndTarget = {
   data: string;
+  encoding?: BufferEncoding;
   target: S3Object;
 };
 
@@ -127,13 +128,14 @@ const getS3ObjectBasic = async (
 export const getS3Object = callWithRetryAndTimeout(getS3ObjectBasic);
 
 const putS3ObjectBasic = async (
-  dataAndTarget: DataAndTarget,
-  encoding: BufferEncoding = "ascii" // default encoding ascii
+  dataAndTarget: DataAndTarget
 ): Promise<void> => {
   if (runViaLambda()) {
     await sendLambdaCommand(IntTestHelpers.putS3Object, dataAndTarget);
     return;
   }
+
+  const encoding = dataAndTarget.encoding ?? "ascii";
 
   const bucketParams = {
     Bucket: dataAndTarget.target.bucket,

--- a/ui-tests/testData/test.setup.ts
+++ b/ui-tests/testData/test.setup.ts
@@ -18,16 +18,14 @@ export const cleanAndUploadExtractFileForUITest = async (): Promise<void> => {
   await deleteS3Objects({ bucket: storageBucket, keys: [key] });
 
   // uploading the file to s3
-  await putS3Object(
-    {
-      data: content,
-      target: {
-        bucket: storageBucket,
-        key,
-      },
+  await putS3Object({
+    data: content,
+    encoding: "utf-8",
+    target: {
+      bucket: storageBucket,
+      key,
     },
-    "utf-8"
-  );
+  });
 
   // verifying that the file exists
   const objectExists = await checkIfS3ObjectExists({


### PR DESCRIPTION
They failed when run with the test helper Lambda function, because an encoding type was not sent to the function when trying to upload the test data, causing the pound symbols to appear incorrectly