### PR TITLE
BTM 747 UI tests fixes

### DIFF
--- a/integration_tests/run-tests.sh
+++ b/integration_tests/run-tests.sh
@@ -23,7 +23,7 @@ npm run test:ui
 
 UI_TESTS_EXIT_CODE=$?
 
-cp reports/ui-test-report*.json $TEST_REPORT_ABSOLUTE_DIR
+cp ./ui-tests/reports/ui-test-report*.json $TEST_REPORT_ABSOLUTE_DIR
 
 if [ $INTEGRATION_TESTS_EXIT_CODE -ne 0 ] || [ $UI_TESTS_EXIT_CODE -ne 0 ] ; then
   exit 1

--- a/ui-tests/helpers/waits.ts
+++ b/ui-tests/helpers/waits.ts
@@ -15,3 +15,18 @@ export const waitForPageLoad = async (): Promise<void> => {
 
   throw new Error("Page did not load within the specified time.");
 };
+
+export const waitForElementDisplayed = async (
+  element: WebdriverIO.Element,
+  timeout: number = 5000
+): Promise<void> => {
+  await browser.waitUntil(
+    async () => {
+      return await element.isDisplayed();
+    },
+    {
+      timeout,
+      timeoutMsg: `Element did not displayed within ${timeout}ms`,
+    }
+  );
+};

--- a/ui-tests/pageobjects/contractsPage.ts
+++ b/ui-tests/pageobjects/contractsPage.ts
@@ -1,4 +1,5 @@
 import Page from "./page";
+import { waitForElementDisplayed } from "../helpers/waits";
 
 class ContractsPage extends Page {
   /**
@@ -13,7 +14,7 @@ class ContractsPage extends Page {
     const contractElements = await this.listOfContracts;
     let matchedElement;
     for (const contract of contractElements) {
-      await contract.waitForDisplayed();
+      await waitForElementDisplayed(contract);
       const text: string = await contract.getText();
       if (text.includes(vendorName)) {
         matchedElement = contract;
@@ -32,7 +33,7 @@ class ContractsPage extends Page {
   public async getListOfContractsText(): Promise<string[]> {
     const listOfContractText: string[] = [];
     for (const contract of await this.listOfContracts) {
-      await contract.waitForDisplayed();
+      await waitForElementDisplayed(contract);
       const text: string = await contract.getText();
       listOfContractText.push(text);
     }

--- a/ui-tests/pageobjects/contractsPage.ts
+++ b/ui-tests/pageobjects/contractsPage.ts
@@ -13,6 +13,7 @@ class ContractsPage extends Page {
     const contractElements = await this.listOfContracts;
     let matchedElement;
     for (const contract of contractElements) {
+      await contract.waitForDisplayed();
       const text: string = await contract.getText();
       if (text.includes(vendorName)) {
         matchedElement = contract;
@@ -31,6 +32,7 @@ class ContractsPage extends Page {
   public async getListOfContractsText(): Promise<string[]> {
     const listOfContractText: string[] = [];
     for (const contract of await this.listOfContracts) {
+      await contract.waitForDisplayed();
       const text: string = await contract.getText();
       listOfContractText.push(text);
     }

--- a/ui-tests/pageobjects/invoicePage.ts
+++ b/ui-tests/pageobjects/invoicePage.ts
@@ -1,4 +1,5 @@
 import Page from "./page";
+import { waitForElementDisplayed } from "../helpers/waits";
 
 class InvoicePage extends Page {
   /**
@@ -42,18 +43,20 @@ class InvoicePage extends Page {
 
   public async getStatusBannerTitle(): Promise<string> {
     const statusBannerTitleElement = await this.statusBannerTitle;
+    await waitForElementDisplayed(statusBannerTitleElement);
     await statusBannerTitleElement.waitForDisplayed();
     return await (await this.statusBannerTitle).getText();
   }
 
   public async getStatusBannerColor(): Promise<string> {
     const statusBannerElement = await this.statusBanner;
-    await statusBannerElement.waitForDisplayed();
+    await waitForElementDisplayed(statusBannerElement);
     const color = await statusBannerElement.getCSSProperty("background-color");
     return color.parsed.hex ?? "";
   }
 
   public async clickOnInvoiceBreadcrumbsLink(): Promise<void> {
+    await waitForElementDisplayed(await this.invoiceBreadcrumbsLink);
     await (await this.invoiceBreadcrumbsLink).click();
   }
 }

--- a/ui-tests/pageobjects/invoicePage.ts
+++ b/ui-tests/pageobjects/invoicePage.ts
@@ -41,7 +41,8 @@ class InvoicePage extends Page {
   }
 
   public async getStatusBannerTitle(): Promise<string> {
-    await (await this.statusBannerTitle).isDisplayed();
+    const statusBannerTitleElement = await this.statusBannerTitle;
+    await statusBannerTitleElement.waitForDisplayed();
     return await (await this.statusBannerTitle).getText();
   }
 

--- a/ui-tests/pageobjects/invoicePage.ts
+++ b/ui-tests/pageobjects/invoicePage.ts
@@ -44,7 +44,6 @@ class InvoicePage extends Page {
   public async getStatusBannerTitle(): Promise<string> {
     const statusBannerTitleElement = await this.statusBannerTitle;
     await waitForElementDisplayed(statusBannerTitleElement);
-    await statusBannerTitleElement.waitForDisplayed();
     return await (await this.statusBannerTitle).getText();
   }
 

--- a/ui-tests/pageobjects/invoicesListPage.ts
+++ b/ui-tests/pageobjects/invoicesListPage.ts
@@ -1,4 +1,5 @@
 import Page from "./page";
+import { waitForElementDisplayed } from "../helpers/waits";
 
 class InvoicesListPage extends Page {
   public get invoicesList(): Promise<WebdriverIO.Element[]> {
@@ -16,6 +17,7 @@ class InvoicesListPage extends Page {
   }
 
   public async clickOnContractsBreadcrumbsLink(): Promise<void> {
+    await waitForElementDisplayed(await this.contractsBreadcrumbsLink);
     await (await this.contractsBreadcrumbsLink).click();
   }
 }

--- a/ui-tests/pageobjects/page.ts
+++ b/ui-tests/pageobjects/page.ts
@@ -1,3 +1,4 @@
+import { waitForElementDisplayed } from "../helpers/waits";
 export default class Page {
   public async open(path: string): Promise<void> {
     await browser.url(`/${path}`);
@@ -24,22 +25,27 @@ export default class Page {
   }
 
   public async isPageHeadingDisplayed(): Promise<boolean> {
+    await waitForElementDisplayed(await this.pageHeading);
     return await (await this.pageHeading).isDisplayed();
   }
 
   public async getPageHeadingText(): Promise<string> {
+    await waitForElementDisplayed(await this.pageHeading);
     return await (await this.pageHeading).getText();
   }
 
   public async isPageSubHeadingDisplayed(): Promise<boolean> {
+    await waitForElementDisplayed(await this.pageSubHeading);
     return await (await this.pageSubHeading).isDisplayed();
   }
 
   public async getPageSubHeadingText(): Promise<string> {
+    await waitForElementDisplayed(await this.pageSubHeading);
     return await (await this.pageSubHeading).getText();
   }
 
   public async getPageParagraphText(): Promise<string> {
+    await waitForElementDisplayed(await this.pageParagraphText);
     return await (await this.pageParagraphText).getText();
   }
 
@@ -47,7 +53,7 @@ export default class Page {
     tableElement: WebdriverIO.Element
   ): Promise<Array<{ [key: string]: string }>> {
     const tableData: Array<{ [key: string]: string }> = [];
-
+    await waitForElementDisplayed(tableElement);
     const rows = await tableElement.$$("tbody tr");
     const headerRow = await tableElement.$("thead tr");
     const headerColumns = await headerRow.$$("th");
@@ -81,6 +87,7 @@ export default class Page {
   }
 
   public async clickOnCookiesFooterLink(): Promise<void> {
+    await waitForElementDisplayed(await this.cookiesFooterLink);
     await (await this.cookiesFooterLink).click();
   }
 }

--- a/ui-tests/pageobjects/page.ts
+++ b/ui-tests/pageobjects/page.ts
@@ -26,7 +26,7 @@ export default class Page {
 
   public async isPageHeadingDisplayed(): Promise<boolean> {
     await waitForElementDisplayed(await this.pageHeading);
-    return await (await this.pageHeading).isDisplayed();
+    return true;
   }
 
   public async getPageHeadingText(): Promise<string> {
@@ -36,7 +36,7 @@ export default class Page {
 
   public async isPageSubHeadingDisplayed(): Promise<boolean> {
     await waitForElementDisplayed(await this.pageSubHeading);
-    return await (await this.pageSubHeading).isDisplayed();
+    return true;
   }
 
   public async getPageSubHeadingText(): Promise<string> {

--- a/ui-tests/specs/invoice.spec.ts
+++ b/ui-tests/specs/invoice.spec.ts
@@ -10,7 +10,7 @@ import {
 } from "../utils/extractTestDatajson";
 import { generateExpectedBannerDetailsFromPercentagePriceDifference } from "../utils/generateExpectedStatusBannerDetails";
 import { generateExpectedStatusFromPercentagePriceDifference } from "../utils/generateExpectedStatusFromPriceDifference";
-import { quarterName } from "../utils/getPrettyMonthName";
+import { quarterName, prettyMonthName } from "../utils/getPrettyMonthName";
 import { getVendorContractIdFromConfig } from "../utils/getVendorContractId";
 import { formatPercentageDifference } from "../utils/invoiceDataFormatters";
 
@@ -63,6 +63,13 @@ describe("Invoice Page Test", () => {
           month,
           invoiceIsQuarterly
         );
+        const pageTitle = await InvoicePage.getPageHeadingText();
+        const monthOrQuarterString = invoiceIsQuarterly
+          ? quarterName(month)
+          : prettyMonthName(month);
+        expect(pageTitle).toContain(
+          `${vendor} (${monthOrQuarterString} ${year})`
+        );
       });
 
       it(`should display correct status banner color and message`, async () => {
@@ -71,6 +78,12 @@ describe("Invoice Page Test", () => {
           year,
           month
         );
+        expectEqual(
+          await InvoicePage.getStatusBannerTitle(),
+          generateExpectedBannerDetailsFromPercentagePriceDifference(
+            priceDifferencePercentage
+          ).bannerMessage
+        );
         const expectedBannerColor =
           generateExpectedBannerDetailsFromPercentagePriceDifference(
             priceDifferencePercentage
@@ -78,12 +91,6 @@ describe("Invoice Page Test", () => {
         expectEqual(
           await InvoicePage.getStatusBannerColor(),
           expectedBannerColor
-        );
-        expectEqual(
-          await InvoicePage.getStatusBannerTitle(),
-          generateExpectedBannerDetailsFromPercentagePriceDifference(
-            priceDifferencePercentage
-          ).bannerMessage
         );
       });
 


### PR DESCRIPTION
Added new utility functin `waitForElementDisplayed` that uses webdriver `waitUntil` function. This new utility method ensures that the UI elements displayed before the test continues
Fixed UI test report path in run-tests.sh file
Added new expect statement in `beforeEach` in the invoiceSpec file to check the page title before the tests.