### PR TITLE
Increase timeout for s3 object deletion in int tests

### DIFF
--- a/src/handlers/int-test-support/helpers/testSetup.ts
+++ b/src/handlers/int-test-support/helpers/testSetup.ts
@@ -36,7 +36,7 @@ const deleteS3ObjectsAndPoll = async (
       }),
     (s3Objects) => s3Objects.length === 0,
     {
-      timeout: 60000,
+      timeout: 80000,
       interval: 10000,
       notCompleteErrorMessage: `${prefix} folder could not be deleted because it still contains objects`,
     }


### PR DESCRIPTION
Modified the `timeout` parameter in `poll` function in `globalSetup.ts` from 60000 to 80000 to resolve recent failures in the pipeline caused by incomplete S3 object deletion.