### PR TITLE
Restart Frontend Lambda Before running UI tests

### DIFF
--- a/src/handlers/int-test-support/helpers/lambdaHelper.ts
+++ b/src/handlers/int-test-support/helpers/lambdaHelper.ts
@@ -1,4 +1,9 @@
-import { InvokeCommand, InvokeCommandInput } from "@aws-sdk/client-lambda";
+import {
+  GetFunctionConfigurationCommand,
+  InvokeCommand,
+  InvokeCommandInput,
+  UpdateFunctionConfigurationCommand,
+} from "@aws-sdk/client-lambda";
 import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-node";
 import { lambdaClient } from "../clients";
 import type { HelperDict } from "../handler";
@@ -63,5 +68,25 @@ const invokeLambda = async (
   } catch (err) {
     console.error(err);
     throw err;
+  }
+};
+
+export const restartLambda = async (functionName: string): Promise<void> => {
+  try {
+    const { Environment } = await lambdaClient.send(
+      new GetFunctionConfigurationCommand({ FunctionName: functionName })
+    );
+    const currentEnv = Environment?.Variables ?? {};
+    const params = {
+      FunctionName: functionName,
+      Environment: {
+        Variables: currentEnv,
+      },
+    };
+    await lambdaClient.send(new UpdateFunctionConfigurationCommand(params));
+    console.log(`Successfully restarted ${functionName}`);
+  } catch (error) {
+    console.error(`Error restarting function ${functionName}:`, error);
+    throw error;
   }
 };

--- a/ui-tests/testData/test.setup.ts
+++ b/ui-tests/testData/test.setup.ts
@@ -5,6 +5,7 @@ import {
   checkIfS3ObjectExists,
 } from "../../src/handlers/int-test-support/helpers/s3Helper";
 import { readJsonDataFromFile } from "../utils/extractTestDatajson";
+import { restartLambda } from "../../src/handlers/int-test-support/helpers/lambdaHelper";
 
 const prefix = resourcePrefix();
 const storageBucket = `${prefix}-storage`;
@@ -33,7 +34,9 @@ export const cleanAndUploadExtractFileForUITest = async (): Promise<void> => {
     key,
   });
 
-  if (!objectExists) {
+  if (objectExists) {
+    await restartLambda(`${prefix}-frontend-function`);
+  } else {
     throw new Error(
       `Failed to verify that the file was uploaded to ${storageBucket}/${key}`
     );


### PR DESCRIPTION
While running UI test after integration tests in the pipleine, the UI was using a cached version of full extract json and this causing ui test failures. So,
Added a `restartLambda` utility function that fetches the current environment variables and triggers a lambda function configuration update, effectively restarting it.
Added the restartLambda function in `cleanAndUploadExtractFileForUITest` function