### PR TITLE
Update IAM permission in int-support CF  for lambda restart 

### DIFF
--- a/cloudformation/intTestSupport.yaml
+++ b/cloudformation/intTestSupport.yaml
@@ -100,6 +100,11 @@ Resources:
               Resource: !Sub arn:aws:ses:${AWS::Region}:${AWS::AccountId}:identity/*
             - Effect: Allow
               Action:
+                - lambda:GetFunctionConfiguration
+                - lambda:UpdateFunctionConfiguration
+              Resource: !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${AWS::StackName}-frontend-function
+            - Effect: Allow
+              Action:
                 - secretsmanager:DescribeSecret
                 - secretsmanager:GetResourcePolicy
                 - secretsmanager:GetSecretValue


### PR DESCRIPTION
added IAM permissions in int-support.yml to restart the frontend lambda before running ui tests to avoid cached data