### PR TITLE
Fix deployment

### DIFF
--- a/cloudformation/dashboard-data-extraction.yaml
+++ b/cloudformation/dashboard-data-extraction.yaml
@@ -21,6 +21,8 @@ Resources:
           QUERY_RESULTS_BUCKET: !Sub s3://${AthenaQueryResultsBucket}
           DESTINATION_BUCKET: !Sub ${AWS::StackName}-storage
           POWERTOOLS_SERVICE_NAME: !Sub ${AWS::StackName}-dashboard-extract-function
+      EventInvokeConfig:
+        MaximumEventAgeInSeconds: 60
       Handler: dashboardExtract.handler
       KmsKeyArn: !GetAtt KmsKey.Arn
       Timeout: 180

--- a/ui-tests/testData/test.setup.ts
+++ b/ui-tests/testData/test.setup.ts
@@ -14,6 +14,9 @@ export const cleanAndUploadExtractFileForUITest = async (): Promise<void> => {
   const filePath = "./ui-tests/testData/testData.txt";
   const content = readJsonDataFromFile(filePath);
 
+  // wait two minutes for any extract function invocations to finish
+  await new Promise((resolve) => setTimeout(resolve, 2 * 60 * 1000));
+
   // deleting existing file with same key
   await deleteS3Objects({ bucket: storageBucket, keys: [key] });
 


### PR DESCRIPTION
Extract function invocations queued up and so ran after UI tests started, overwriting test data

Function takes 1min in dev, so if 1min is max invocation event age, waiting 2min should work