### PR TITLE
change logging for S3 access to debug and add info logs for bucketing

### DIFF
--- a/src/shared/utils/s3/base.ts
+++ b/src/shared/utils/s3/base.ts
@@ -197,7 +197,7 @@ const send = async <T extends ServiceInputTypes, U extends ServiceOutputTypes>(
   await s3
     .send(command)
     .then((data) => {
-      logger.info("Sent S3 command", { metadata: data.$metadata });
+      logger.debug("Sent S3 command", { metadata: data.$metadata });
       return data;
     })
     .catch((err) => {


### PR DESCRIPTION
there are too many generic info logs spammed during bucketing to tell what the problem is in production. Bucketing retested in dev and still working so added extra logging also to help debug prod issue.